### PR TITLE
feat(home): Projection Gap Simulator (interactive wizard)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1089,9 +1089,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1107,9 +1104,6 @@
       "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1127,9 +1121,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1145,9 +1136,6 @@
       "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1165,9 +1153,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1183,9 +1168,6 @@
       "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1203,9 +1185,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1222,9 +1201,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1240,9 +1216,6 @@
       "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1266,9 +1239,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1290,9 +1260,6 @@
       "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1316,9 +1283,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1340,9 +1304,6 @@
       "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1366,9 +1327,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1391,9 +1349,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1415,9 +1370,6 @@
       "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1790,9 +1742,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1808,9 +1757,6 @@
       "integrity": "sha512-iVMMp14514u7Nup2umQS03nT/bN9HurK8ufylC3FZNykrwjtx7V1A7+4kvhbDSCeonTVqV3Txnv0Lu+m2oDXNg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1828,9 +1774,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1846,9 +1789,6 @@
       "integrity": "sha512-h9FxsngCm9cTBf71AR4fGznDEDx1hS7+kSEiIRjq5kO1oXWm07DxVGZjCvk0SGx7TSjlUqhI8oOyz7NfwAdPoA==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2164,9 +2104,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2184,9 +2121,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2204,9 +2138,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2224,9 +2155,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2872,9 +2800,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2889,9 +2814,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2906,9 +2828,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2923,9 +2842,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2940,9 +2856,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2957,9 +2870,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2974,9 +2884,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2991,9 +2898,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6751,9 +6655,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6775,9 +6676,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6799,9 +6697,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6823,9 +6718,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -127,7 +127,7 @@
     @apply bg-background text-foreground antialiased;
   }
   html {
-    @apply scroll-smooth;
+    @apply scroll-smooth overflow-x-hidden;
   }
   ::-webkit-scrollbar {
     width: 6px;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -29,7 +29,7 @@ export default function RootLayout({
   return (
     <html lang="en" className="dark" suppressHydrationWarning>
       <body
-        className={`${geistSans.variable} ${geistMono.variable} min-h-screen bg-background font-sans antialiased`}
+        className={`${geistSans.variable} ${geistMono.variable} min-h-dvh min-h-screen bg-background font-sans antialiased`}
       >
         {children}
       </body>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,7 @@
 import { useState } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import Link from "next/link";
+import { ProjectionGapSimulator } from "@/components/projection-gap-simulator";
 import {
   ArrowDownIcon,
   ArrowRightIcon,
@@ -163,38 +164,58 @@ export default function Home() {
             backgroundSize: "64px 64px",
           }}
         />
-        <div className="relative mx-auto max-w-5xl px-6 py-16 text-center">
-          <motion.div
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.6 }}
-          >
-            <div className="mx-auto mb-6 inline-flex items-center gap-2 rounded-full border border-border bg-muted/50 px-4 py-1.5 text-sm">
-              <CompassIcon className="h-4 w-4 text-primary" />
-              Vendor Corp. Action Intelligence
-            </div>
-            <h1 className="mb-4 text-4xl font-bold tracking-tight md:text-5xl lg:text-6xl">
-              Why does one vendor show it —
-              <br className="hidden md:block" />
-              <span className="text-primary"> but not the others?</span>
-            </h1>
-            <p className="mx-auto mb-10 max-w-2xl text-lg text-muted-foreground">
-              Same event, same security, different projection data. Walk through the
-              decision tree to find exactly where the divergence originates — then
-              check vendor thresholds in the reference.
-            </p>
+        <div className="relative mx-auto max-w-6xl px-6 py-12 md:py-16">
+          <div className="grid gap-10 lg:grid-cols-2 lg:items-start lg:gap-12">
+            <div className="text-center lg:text-left">
+              <motion.div
+                initial={{ opacity: 0, y: 20 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ duration: 0.6 }}
+              >
+                <div className="mx-auto mb-6 inline-flex items-center gap-2 rounded-full border border-border bg-muted/50 px-4 py-1.5 text-sm lg:mx-0">
+                  <CompassIcon className="h-4 w-4 text-primary" />
+                  Vendor Corp. Action Intelligence
+                </div>
+                <h1 className="mb-4 text-4xl font-bold tracking-tight md:text-5xl lg:text-6xl">
+                  Why does one vendor show it —
+                  <br className="hidden md:block" />
+                  <span className="text-primary"> but not the others?</span>
+                </h1>
+                <p className="mx-auto mb-8 max-w-2xl text-lg text-muted-foreground lg:mx-0">
+                  Same event, same security, different projection data. Use the simulator
+                  for a quick hypothesis, or walk the full decision tree — then check vendor
+                  thresholds in the reference.
+                </p>
 
-            <button
-              onClick={() => {
-                document.getElementById("decision-tree")?.scrollIntoView({ behavior: "smooth" });
-              }}
-              className="inline-flex items-center gap-2 rounded-xl bg-primary px-8 py-4 text-base font-semibold text-primary-foreground shadow-lg transition-all hover:bg-primary/90 hover:shadow-xl"
-            >
-              <ZapIcon className="h-5 w-5" />
-              Start the Decision Tree
-              <ArrowDownIcon className="h-4 w-4" />
-            </button>
-          </motion.div>
+                <div className="flex flex-col items-stretch justify-center gap-3 sm:flex-row sm:flex-wrap lg:justify-start">
+                  <button
+                    type="button"
+                    onClick={() => {
+                      document.getElementById("projection-gap-simulator")?.scrollIntoView({ behavior: "smooth" });
+                    }}
+                    className="inline-flex items-center justify-center gap-2 rounded-xl bg-primary px-6 py-3.5 text-base font-semibold text-primary-foreground shadow-lg transition-all hover:bg-primary/90 hover:shadow-xl sm:px-8 sm:py-4"
+                  >
+                    <ZapIcon className="h-5 w-5" />
+                    Projection gap simulator
+                    <ArrowDownIcon className="h-4 w-4" />
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      document.getElementById("decision-tree")?.scrollIntoView({ behavior: "smooth" });
+                    }}
+                    className="inline-flex items-center justify-center gap-2 rounded-xl border border-border bg-card px-6 py-3.5 text-base font-semibold text-foreground shadow-sm transition-all hover:border-primary/50 hover:bg-muted/50 sm:px-8 sm:py-4"
+                  >
+                    Decision tree
+                    <ArrowDownIcon className="h-4 w-4" />
+                  </button>
+                </div>
+              </motion.div>
+            </div>
+            <div className="lg:sticky lg:top-8">
+              <ProjectionGapSimulator />
+            </div>
+          </div>
         </div>
       </section>
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,6 +3,7 @@ import { useState } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import Link from "next/link";
 import { ProjectionGapSimulator } from "@/components/projection-gap-simulator";
+import { SurfaceSection } from "@/components/surface-section";
 import {
   ArrowDownIcon,
   ArrowRightIcon,
@@ -221,7 +222,7 @@ export default function Home() {
 
       {/* ── Real Scenarios ─────────────────────────────────────────────── */}
       <section className="mx-auto max-w-6xl px-6 py-16">
-        <div className="rounded-[2rem] border border-white/10 bg-gradient-to-br from-card/95 via-card/90 to-primary/5 p-6 shadow-xl ring-1 ring-white/5 sm:p-8 md:p-10">
+        <SurfaceSection padding="comfortable">
         <div className="mb-8">
           <h2 className="mb-2 text-2xl font-bold">Real Scenarios from Operations</h2>
           <p className="text-sm text-muted-foreground">
@@ -282,12 +283,12 @@ export default function Home() {
             </motion.div>
           )}
         </AnimatePresence>
-        </div>
+        </SurfaceSection>
       </section>
 
       {/* ── Decision Tree ───────────────────────────────────────────────── */}
       <section id="decision-tree" className="mx-auto max-w-6xl border-t border-border px-6 py-16">
-        <div className="rounded-[2rem] border border-white/10 bg-gradient-to-br from-card/95 via-card/90 to-primary/5 p-6 shadow-xl ring-1 ring-white/5 sm:p-8 md:p-10">
+        <SurfaceSection padding="comfortable">
         <div className="mb-8">
           <h2 className="mb-2 text-2xl font-bold">Find the Divergence Point</h2>
           <p className="text-sm text-muted-foreground">
@@ -400,12 +401,12 @@ export default function Home() {
             </div>
           </div>
         </div>
-        </div>
+        </SurfaceSection>
       </section>
 
       {/* ── Coverage Period (supplementary) ───────────────────────────── */}
       <section className="mx-auto max-w-6xl border-t border-border px-6 py-12">
-        <div className="rounded-[2rem] border border-white/10 bg-gradient-to-br from-card/95 via-card/90 to-primary/5 p-6 shadow-xl ring-1 ring-white/5 sm:p-8">
+        <SurfaceSection padding="compact">
         <div className="mb-4">
           <h2 className="text-sm font-semibold text-muted-foreground">Supplementary — Coverage Period</h2>
         </div>
@@ -426,12 +427,12 @@ export default function Home() {
             ))}
           </div>
         </div>
-        </div>
+        </SurfaceSection>
       </section>
 
       {/* ── Quick Links ─────────────────────────────────────────────────── */}
       <section className="mx-auto max-w-6xl border-t border-border px-6 py-12">
-        <div className="rounded-[2rem] border border-white/10 bg-gradient-to-br from-card/95 via-card/90 to-primary/5 p-6 shadow-xl ring-1 ring-white/5 sm:p-8">
+        <SurfaceSection padding="compact">
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
           <Link
             href="/vendors/"
@@ -461,7 +462,7 @@ export default function Home() {
             </p>
           </div>
         </div>
-        </div>
+        </SurfaceSection>
       </section>
     </main>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -164,8 +164,8 @@ export default function Home() {
             backgroundSize: "64px 64px",
           }}
         />
-        <div className="relative mx-auto max-w-6xl px-6 py-12 md:py-16">
-          <div className="grid gap-10 xl:grid-cols-2 xl:items-start xl:gap-12">
+        <div className="relative mx-auto max-w-7xl px-6 py-12 md:py-16">
+          <div className="grid gap-10 xl:grid-cols-[minmax(0,1fr)_minmax(0,1.35fr)] xl:items-start xl:gap-12">
             <div className="min-w-0 text-center xl:text-left">
               <motion.div
                 initial={{ opacity: 0, y: 20 }}
@@ -220,7 +220,8 @@ export default function Home() {
       </section>
 
       {/* ── Real Scenarios ─────────────────────────────────────────────── */}
-      <section className="mx-auto max-w-5xl px-6 py-16">
+      <section className="mx-auto max-w-6xl px-6 py-16">
+        <div className="rounded-[2rem] border border-white/10 bg-gradient-to-br from-card/95 via-card/90 to-primary/5 p-6 shadow-xl ring-1 ring-white/5 sm:p-8 md:p-10">
         <div className="mb-8">
           <h2 className="mb-2 text-2xl font-bold">Real Scenarios from Operations</h2>
           <p className="text-sm text-muted-foreground">
@@ -281,10 +282,12 @@ export default function Home() {
             </motion.div>
           )}
         </AnimatePresence>
+        </div>
       </section>
 
       {/* ── Decision Tree ───────────────────────────────────────────────── */}
-      <section id="decision-tree" className="mx-auto max-w-5xl px-6 py-16 border-t border-border">
+      <section id="decision-tree" className="mx-auto max-w-6xl border-t border-border px-6 py-16">
+        <div className="rounded-[2rem] border border-white/10 bg-gradient-to-br from-card/95 via-card/90 to-primary/5 p-6 shadow-xl ring-1 ring-white/5 sm:p-8 md:p-10">
         <div className="mb-8">
           <h2 className="mb-2 text-2xl font-bold">Find the Divergence Point</h2>
           <p className="text-sm text-muted-foreground">
@@ -294,7 +297,7 @@ export default function Home() {
 
         <div className="space-y-6">
           {TREE_STEPS.map((s) => (
-            <div key={s.step} className="rounded-2xl border border-border bg-card overflow-hidden">
+            <div key={s.step} className="overflow-hidden rounded-xl border border-border bg-background/40">
               <div className="flex items-start gap-4 p-5">
                 <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-primary/10 text-sm font-bold text-primary">
                   {s.step}
@@ -345,7 +348,7 @@ export default function Home() {
         )}
 
         {/* ── Event Timeline ──────────────────────────────────────────── */}
-        <div className="mt-12 rounded-2xl border border-border bg-card p-6">
+        <div className="mt-12 rounded-xl border border-border bg-background/40 p-6">
           <h3 className="mb-4 text-sm font-semibold">How a Corporate Action Moves Through the System</h3>
           <div className="relative">
             {/* Timeline line */}
@@ -397,10 +400,12 @@ export default function Home() {
             </div>
           </div>
         </div>
+        </div>
       </section>
 
       {/* ── Coverage Period (supplementary) ───────────────────────────── */}
-      <section className="mx-auto max-w-5xl px-6 py-12 border-t border-border">
+      <section className="mx-auto max-w-6xl border-t border-border px-6 py-12">
+        <div className="rounded-[2rem] border border-white/10 bg-gradient-to-br from-card/95 via-card/90 to-primary/5 p-6 shadow-xl ring-1 ring-white/5 sm:p-8">
         <div className="mb-4">
           <h2 className="text-sm font-semibold text-muted-foreground">Supplementary — Coverage Period</h2>
         </div>
@@ -421,11 +426,13 @@ export default function Home() {
             ))}
           </div>
         </div>
+        </div>
       </section>
 
       {/* ── Quick Links ─────────────────────────────────────────────────── */}
-      <section className="mx-auto max-w-5xl px-6 py-12 border-t border-border">
-        <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+      <section className="mx-auto max-w-6xl border-t border-border px-6 py-12">
+        <div className="rounded-[2rem] border border-white/10 bg-gradient-to-br from-card/95 via-card/90 to-primary/5 p-6 shadow-xl ring-1 ring-white/5 sm:p-8">
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
           <Link
             href="/vendors/"
             className="rounded-2xl border border-border bg-card p-5 transition-all hover:border-primary/50 hover:bg-muted/50"
@@ -453,6 +460,7 @@ export default function Home() {
               Include ticker and event date for fastest response
             </p>
           </div>
+        </div>
         </div>
       </section>
     </main>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -212,7 +212,7 @@ export default function Home() {
                 </div>
               </motion.div>
             </div>
-            <div className="lg:sticky lg:top-8">
+            <div className="min-w-0 lg:self-start">
               <ProjectionGapSimulator />
             </div>
           </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -165,14 +165,14 @@ export default function Home() {
           }}
         />
         <div className="relative mx-auto max-w-6xl px-6 py-12 md:py-16">
-          <div className="grid gap-10 lg:grid-cols-2 lg:items-start lg:gap-12">
-            <div className="text-center lg:text-left">
+          <div className="grid gap-10 xl:grid-cols-2 xl:items-start xl:gap-12">
+            <div className="min-w-0 text-center xl:text-left">
               <motion.div
                 initial={{ opacity: 0, y: 20 }}
                 animate={{ opacity: 1, y: 0 }}
                 transition={{ duration: 0.6 }}
               >
-                <div className="mx-auto mb-6 inline-flex items-center gap-2 rounded-full border border-border bg-muted/50 px-4 py-1.5 text-sm lg:mx-0">
+                <div className="mx-auto mb-6 inline-flex items-center gap-2 rounded-full border border-border bg-muted/50 px-4 py-1.5 text-sm xl:mx-0">
                   <CompassIcon className="h-4 w-4 text-primary" />
                   Vendor Corp. Action Intelligence
                 </div>
@@ -181,13 +181,13 @@ export default function Home() {
                   <br className="hidden md:block" />
                   <span className="text-primary"> but not the others?</span>
                 </h1>
-                <p className="mx-auto mb-8 max-w-2xl text-lg text-muted-foreground lg:mx-0">
+                <p className="mx-auto mb-8 max-w-2xl text-lg text-muted-foreground xl:mx-0">
                   Same event, same security, different projection data. Use the simulator
                   for a quick hypothesis, or walk the full decision tree — then check vendor
                   thresholds in the reference.
                 </p>
 
-                <div className="flex flex-col items-stretch justify-center gap-3 sm:flex-row sm:flex-wrap lg:justify-start">
+                <div className="flex flex-col items-stretch justify-center gap-3 sm:flex-row sm:flex-wrap xl:justify-start">
                   <button
                     type="button"
                     onClick={() => {
@@ -212,7 +212,7 @@ export default function Home() {
                 </div>
               </motion.div>
             </div>
-            <div className="min-w-0 lg:self-start">
+            <div className="min-w-0 w-full max-w-full xl:self-start">
               <ProjectionGapSimulator />
             </div>
           </div>

--- a/src/app/vendors/event-extraction/page.tsx
+++ b/src/app/vendors/event-extraction/page.tsx
@@ -30,7 +30,8 @@ export default async function EventExtractionPage() {
         </div>
       </header>
 
-      <main className="mx-auto max-w-5xl px-4 sm:px-6 py-8">
+      <main className="mx-auto max-w-5xl px-4 py-8 sm:px-6">
+        <div className="rounded-[2rem] border border-white/10 bg-gradient-to-br from-card/95 via-card/90 to-primary/5 p-5 shadow-xl ring-1 ring-white/5 sm:p-8">
         <div
           className="prose prose-invert max-w-none"
           style={{
@@ -39,6 +40,7 @@ export default async function EventExtractionPage() {
           }}
           dangerouslySetInnerHTML={{ __html: renderMarkdown(content) }}
         />
+        </div>
       </main>
     </div>
   );

--- a/src/app/vendors/event-extraction/page.tsx
+++ b/src/app/vendors/event-extraction/page.tsx
@@ -106,12 +106,12 @@ function renderMarkdown(md: string): string {
     const bodyRows = rows.slice(1);
     let table = `<table style="width:100%;border-collapse:collapse;font-size:0.8rem;margin-bottom:1.5rem;overflow-x:auto;display:block;">`;
     table += `<thead><tr style="background:oklch(0.2 0.015 260);">`;
-    table += headerCells.map((c, i) => `<th style="padding:0.5rem 0.75rem;text-align:left;font-weight:600;color:oklch(0.72 0.19 250);border-bottom:1px solid oklch(0.25 0.015 260);white-space:nowrap;">${inline(c)}</th>`).join("");
+    table += headerCells.map((c) => `<th style="padding:0.5rem 0.75rem;text-align:left;font-weight:600;color:oklch(0.72 0.19 250);border-bottom:1px solid oklch(0.25 0.015 260);white-space:nowrap;">${inline(c)}</th>`).join("");
     table += `</tr></thead><tbody>`;
     bodyRows.forEach(row => {
       const cells = row.slice(1, -1).split("|").map(c => c.trim());
       table += `<tr style="border-bottom:1px solid oklch(0.2 0.015 260);">`;
-      table += cells.map((c, i) => `<td style="padding:0.4rem 0.75rem;vertical-align:top;color:oklch(0.75 0.01 260);white-space:nowrap;">${inline(c)}</td>`).join("");
+      table += cells.map((c) => `<td style="padding:0.4rem 0.75rem;vertical-align:top;color:oklch(0.75 0.01 260);white-space:nowrap;">${inline(c)}</td>`).join("");
       table += `</tr>`;
     });
     table += `</tbody></table>`;

--- a/src/app/vendors/event-extraction/page.tsx
+++ b/src/app/vendors/event-extraction/page.tsx
@@ -1,6 +1,8 @@
 import { promises as fs } from "fs";
 import path from "path";
 
+import { SurfaceSection } from "@/components/surface-section";
+
 export default async function EventExtractionPage() {
   const filePath = path.join(
     process.cwd(),
@@ -31,7 +33,7 @@ export default async function EventExtractionPage() {
       </header>
 
       <main className="mx-auto max-w-5xl px-4 py-8 sm:px-6">
-        <div className="rounded-[2rem] border border-white/10 bg-gradient-to-br from-card/95 via-card/90 to-primary/5 p-5 shadow-xl ring-1 ring-white/5 sm:p-8">
+        <SurfaceSection padding="tight">
         <div
           className="prose prose-invert max-w-none"
           style={{
@@ -40,7 +42,7 @@ export default async function EventExtractionPage() {
           }}
           dangerouslySetInnerHTML={{ __html: renderMarkdown(content) }}
         />
-        </div>
+        </SurfaceSection>
       </main>
     </div>
   );

--- a/src/app/vendors/iso-taxonomy/page.tsx
+++ b/src/app/vendors/iso-taxonomy/page.tsx
@@ -10,6 +10,8 @@ import {
 } from "lucide-react";
 import Link from "next/link";
 
+import { SurfaceSection } from "@/components/surface-section";
+
 type EventRow = {
   masterCategory: string;
   isoCAEV: string;
@@ -301,7 +303,7 @@ export default function IsoTaxonomyPage() {
       </header>
 
       <main className="mx-auto max-w-7xl space-y-8 px-4 py-8 sm:px-6">
-        <div className="rounded-[2rem] border border-white/10 bg-gradient-to-br from-card/95 via-card/90 to-primary/5 p-5 shadow-xl ring-1 ring-white/5 sm:p-8 space-y-8">
+        <SurfaceSection padding="tight" className="space-y-8">
         {/* Hero */}
         <div className="rounded-2xl border border-border bg-gradient-to-br from-card to-background p-6 sm:p-8">
           <div className="flex items-start gap-4">
@@ -504,7 +506,7 @@ export default function IsoTaxonomyPage() {
             <div>:70E:  ADDB/OFFEROR/ACME CORP</div>
           </div>
         </div>
-        </div>
+        </SurfaceSection>
       </main>
     </div>
   );

--- a/src/app/vendors/iso-taxonomy/page.tsx
+++ b/src/app/vendors/iso-taxonomy/page.tsx
@@ -300,7 +300,8 @@ export default function IsoTaxonomyPage() {
         </div>
       </header>
 
-      <main className="mx-auto max-w-7xl px-4 sm:px-6 py-8 space-y-8">
+      <main className="mx-auto max-w-7xl space-y-8 px-4 py-8 sm:px-6">
+        <div className="rounded-[2rem] border border-white/10 bg-gradient-to-br from-card/95 via-card/90 to-primary/5 p-5 shadow-xl ring-1 ring-white/5 sm:p-8 space-y-8">
         {/* Hero */}
         <div className="rounded-2xl border border-border bg-gradient-to-br from-card to-background p-6 sm:p-8">
           <div className="flex items-start gap-4">
@@ -502,6 +503,7 @@ export default function IsoTaxonomyPage() {
             <div>:36B:  ELIG/UNIT/1000</div>
             <div>:70E:  ADDB/OFFEROR/ACME CORP</div>
           </div>
+        </div>
         </div>
       </main>
     </div>

--- a/src/app/vendors/page.tsx
+++ b/src/app/vendors/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useRef } from "react";
 import Link from "next/link";
+import { surfaceOuterClass } from "@/components/surface-section";
 import { motion, AnimatePresence } from "framer-motion";
 import {
   ArrowLeftIcon,
@@ -964,7 +965,9 @@ export default function VendorDashboard() {
               </div>
 
           {/* Main Content */}
-          <main className="order-1 min-w-0 flex-1 rounded-[2rem] border border-white/10 bg-gradient-to-br from-card/95 via-card/90 to-primary/5 p-5 shadow-xl ring-1 ring-white/5 sm:p-8 lg:order-2">
+          <main
+            className={`order-1 min-w-0 flex-1 p-5 shadow-xl sm:p-8 lg:order-2 ${surfaceOuterClass}`}
+          >
 
             {/* Event Header */}
             <div className="mb-6">

--- a/src/app/vendors/page.tsx
+++ b/src/app/vendors/page.tsx
@@ -964,7 +964,7 @@ export default function VendorDashboard() {
               </div>
 
           {/* Main Content */}
-          <main className="min-w-0 flex-1 order-1 lg:order-2">
+          <main className="order-1 min-w-0 flex-1 rounded-[2rem] border border-white/10 bg-gradient-to-br from-card/95 via-card/90 to-primary/5 p-5 shadow-xl ring-1 ring-white/5 sm:p-8 lg:order-2">
 
             {/* Event Header */}
             <div className="mb-6">

--- a/src/components/projection-gap-simulator.tsx
+++ b/src/components/projection-gap-simulator.tsx
@@ -3,17 +3,25 @@
 import { useMemo, useState } from "react";
 import Link from "next/link";
 import { AnimatePresence, motion } from "framer-motion";
-import { ArrowLeftIcon, ArrowRightIcon, SparklesIcon } from "lucide-react";
+import { ArrowLeftIcon, ArrowRightIcon, CheckIcon } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { VENDOR_IDS, vendorLabel, type VendorId } from "@/lib/vendors";
 import { runSimulator } from "@/lib/simulator/simulator-engine";
-import type { SimulatorInput, SimulatorResult } from "@/lib/simulator/types";
+import {
+  familiesForClass,
+  getEventClassFromFamily,
+  humanFamily,
+} from "@/lib/simulator/taxonomy";
+import type { EventFamily, SimulatorInput, SimulatorResult } from "@/lib/simulator/types";
 
-const STEPS = [
-  "Event",
-  "Details",
+const STEP_COUNT = 6;
+
+const STEP_LABELS = [
+  "Category",
+  "Event type",
+  "Context",
   "Dates",
   "Vendors",
   "Results",
@@ -27,8 +35,15 @@ function todayIso(): string {
   return `${y}-${m}-${day}`;
 }
 
+const defaultMetrics = (): SimulatorInput["metrics"] => ({
+  dividendYieldPct: "",
+  freeFloatChangePp: "",
+  tenderAcceptancePct: "",
+  rightsDiscountPct: "",
+});
+
 const defaultInput = (): SimulatorInput => ({
-  eventClass: "mandatory",
+  eventCategory: "mandatory",
   eventFamily: "merger",
   rightsItm: "unknown",
   rightsSubscriptionKnown: true,
@@ -38,6 +53,7 @@ const defaultInput = (): SimulatorInput => ({
   spinoffPhase: "unknown",
   dividendFlavor: "unknown",
   indexReturnVariant: "unknown",
+  metrics: defaultMetrics(),
   effectiveDate: "",
   exDate: "",
   dataAsOf: todayIso(),
@@ -46,14 +62,27 @@ const defaultInput = (): SimulatorInput => ({
   notes: "",
 });
 
-function relevanceStyles(r: "high" | "medium" | "low"): string {
-  if (r === "high") return "border-primary/40 bg-primary/10 text-primary";
-  if (r === "medium") return "border-amber-500/30 bg-amber-500/10 text-amber-200";
-  return "border-border bg-muted/30 text-muted-foreground";
+function relevanceTone(r: "high" | "medium" | "low"): string {
+  if (r === "high") return "bg-primary/12 border-primary/25";
+  if (r === "medium") return "bg-amber-500/8 border-amber-500/20";
+  return "bg-muted/40 border-border";
 }
 
 function toggleVendor(list: VendorId[], id: VendorId): VendorId[] {
   return list.includes(id) ? list.filter((x) => x !== id) : [...list, id];
+}
+
+function familyLabel(f: EventFamily): string {
+  return humanFamily(f);
+}
+
+function coerceFamilyForCategory(
+  category: SimulatorInput["eventCategory"],
+  current: EventFamily,
+): EventFamily {
+  const allowed = familiesForClass(category);
+  if (allowed.includes(current)) return current;
+  return allowed[0] ?? current;
 }
 
 export function ProjectionGapSimulator() {
@@ -61,6 +90,13 @@ export function ProjectionGapSimulator() {
   const [input, setInput] = useState<SimulatorInput>(defaultInput);
   const [result, setResult] = useState<SimulatorResult | null>(null);
   const [stepError, setStepError] = useState<string | null>(null);
+
+  const allowedFamilies = useMemo(
+    () => familiesForClass(input.eventCategory),
+    [input.eventCategory],
+  );
+
+  const impliedClass = getEventClassFromFamily(input.eventFamily);
 
   const canShowSubdetails = useMemo(() => {
     const f = input.eventFamily;
@@ -72,42 +108,56 @@ export function ProjectionGapSimulator() {
     );
   }, [input.eventFamily]);
 
-  function validateCurrent(): string | null {
-    if (step === 0) return null;
-    if (step === 1) {
-      return null;
+  function validateStep(s: number): string | null {
+    if (s === 3) {
+      if (!input.effectiveDate) return "Add an effective date to continue.";
+      if (!input.dataAsOf) return "Add the projection “as of” date.";
     }
-    if (step === 2) {
-      if (!input.effectiveDate) return "Please set an effective date.";
-      if (!input.dataAsOf) return "Please set the projection “as of” date.";
-      return null;
-    }
-    if (step === 3) {
+    if (s === 4) {
       if (input.missingVendors.length === 0 || input.presentVendors.length === 0) {
-        return "Select at least one vendor that appears missing and at least one that sent a projection file.";
+        return "Pick at least one vendor that looks missing and one that already sent a file.";
       }
-      return null;
     }
     return null;
   }
 
+  function goToStep(target: number) {
+    const clamped = Math.max(0, Math.min(target, STEP_COUNT - 1));
+    if (clamped < STEP_COUNT - 1) setResult(null);
+    setStepError(null);
+    if (clamped < step) {
+      setStep(clamped);
+      return;
+    }
+    for (let s = step; s < clamped; s++) {
+      const err = validateStep(s);
+      if (err) {
+        setStepError(err);
+        setStep(s);
+        return;
+      }
+    }
+    setStep(clamped);
+  }
+
   function goNext() {
-    const err = validateCurrent();
+    const err = validateStep(step);
     if (err) {
       setStepError(err);
       return;
     }
     setStepError(null);
-    if (step === 3) {
+    if (step === STEP_COUNT - 2) {
       setResult(runSimulator(input));
-      setStep(4);
+      setStep(STEP_COUNT - 1);
       return;
     }
-    setStep((s) => Math.min(s + 1, STEPS.length - 1));
+    setStep((s) => Math.min(s + 1, STEP_COUNT - 1));
   }
 
   function goBack() {
     setStepError(null);
+    if (step === STEP_COUNT - 1) setResult(null);
     setStep((s) => Math.max(s - 1, 0));
   }
 
@@ -121,535 +171,696 @@ export function ProjectionGapSimulator() {
   return (
     <section
       id="projection-gap-simulator"
-      className="relative mx-auto max-w-3xl rounded-3xl border border-border bg-card/80 p-6 shadow-xl shadow-black/20 backdrop-blur-md md:p-8"
+      className="relative overflow-hidden rounded-[2rem] border border-white/10 bg-gradient-to-br from-card/95 via-card/90 to-primary/5 p-5 shadow-2xl shadow-black/25 ring-1 ring-white/5 sm:p-8 md:p-10"
       aria-labelledby="simulator-heading"
     >
-      <div className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
-        <div>
-          <div className="mb-2 inline-flex items-center gap-2 rounded-full border border-primary/30 bg-primary/10 px-3 py-1 text-xs font-medium text-primary">
-            <SparklesIcon className="size-3.5" aria-hidden />
-            Interactive
-          </div>
-          <h2 id="simulator-heading" className="text-xl font-bold tracking-tight md:text-2xl">
-            Projection gap simulator
-          </h2>
-          <p className="mt-1 max-w-xl text-sm text-muted-foreground">
-            Describe the event, dates, and which vendors differ. You will get ranked, explainable hypotheses — not vendor guarantees.
-          </p>
-        </div>
-        <div className="flex shrink-0 gap-1 rounded-xl border border-border bg-background/80 p-1">
-          {STEPS.map((label, i) => (
-            <div
-              key={label}
-              className={cn(
-                "flex min-w-0 flex-1 items-center justify-center rounded-lg px-2 py-1.5 text-center text-[10px] font-semibold uppercase tracking-wide sm:text-xs",
-                i === step
-                  ? "bg-primary text-primary-foreground"
-                  : i < step
-                    ? "text-muted-foreground"
-                    : "text-muted-foreground/60",
-              )}
-              title={label}
-            >
-              <span className="truncate">{label}</span>
-            </div>
-          ))}
-        </div>
-      </div>
+      <div className="pointer-events-none absolute -right-24 -top-24 size-72 rounded-full bg-primary/15 blur-3xl" aria-hidden />
+      <div className="pointer-events-none absolute -bottom-32 -left-16 size-64 rounded-full bg-foreground/5 blur-3xl" aria-hidden />
 
-      <AnimatePresence mode="wait">
-        <motion.div
-          key={step}
-          initial={{ opacity: 0, x: 12 }}
-          animate={{ opacity: 1, x: 0 }}
-          exit={{ opacity: 0, x: -12 }}
-          transition={{ duration: 0.2 }}
-          className="min-h-[220px]"
+      <div className="relative flex flex-col gap-8 lg:flex-row lg:gap-10">
+        {/* Step rail — full labels, no truncation */}
+        <nav
+          className="shrink-0 lg:w-52"
+          aria-label="Simulator steps"
         >
-          {step === 0 && (
-            <div className="space-y-6">
-              <fieldset>
-                <legend className="mb-3 text-sm font-semibold">Event class</legend>
-                <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
-                  {(
-                    [
-                      { v: "mandatory" as const, t: "Mandatory", d: "Confirmed facts — dividend, split, merger, spin-off…" },
-                      { v: "voluntary" as const, t: "Voluntary", d: "Shareholder choice — rights, tender, partial offer…" },
-                    ] as const
-                  ).map((o) => (
-                    <button
-                      key={o.v}
-                      type="button"
-                      onClick={() => setInput((p) => ({ ...p, eventClass: o.v }))}
-                      className={cn(
-                        "rounded-2xl border p-4 text-left text-sm transition-all hover:border-primary/50",
-                        input.eventClass === o.v
-                          ? "border-primary bg-primary/10"
-                          : "border-border bg-background/50",
-                      )}
-                    >
-                      <div className="font-semibold">{o.t}</div>
-                      <div className="mt-1 text-xs text-muted-foreground">{o.d}</div>
-                    </button>
-                  ))}
-                </div>
-              </fieldset>
-
-              <fieldset>
-                <legend className="mb-3 text-sm font-semibold">Event family</legend>
-                <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
-                  {(
-                    [
-                      ["dividend", "Dividend"],
-                      ["split", "Split / consolidation"],
-                      ["merger", "M&A"],
-                      ["spinoff", "Spin-off"],
-                      ["rights", "Rights issue"],
-                      ["tender", "Tender / buyback"],
-                      ["return_of_capital", "Return of capital"],
-                      ["delisting", "Delisting"],
-                      ["other", "Other"],
-                    ] as const
-                  ).map(([value, label]) => (
-                    <button
-                      key={value}
-                      type="button"
-                      onClick={() =>
-                        setInput((p) => ({
-                          ...p,
-                          eventFamily: value,
-                        }))
-                      }
-                      className={cn(
-                        "rounded-xl border px-3 py-2.5 text-left text-xs font-medium transition-all hover:border-primary/50 sm:text-sm",
-                        input.eventFamily === value
-                          ? "border-primary bg-primary/10 text-foreground"
-                          : "border-border bg-background/50 text-muted-foreground",
-                      )}
-                    >
-                      {label}
-                    </button>
-                  ))}
-                </div>
-              </fieldset>
-            </div>
-          )}
-
-          {step === 1 && (
-            <div className="space-y-6">
-              {!canShowSubdetails ? (
-                <p className="text-sm text-muted-foreground">
-                  No extra fields are required for this event family in the pilot. You can continue to dates — or pick M&A, spin-off, rights, or dividend for deeper prompts.
-                </p>
-              ) : (
-                <>
-                  {input.eventFamily === "rights" && (
-                    <fieldset>
-                      <legend className="mb-3 text-sm font-semibold">Rights — money-ness</legend>
-                      <div className="grid grid-cols-1 gap-2 sm:grid-cols-3">
-                        {(
-                          [
-                            ["itm", "In-the-money"],
-                            ["otm", "Out-of-the-money"],
-                            ["unknown", "Unknown / unsure"],
-                          ] as const
-                        ).map(([v, label]) => (
-                          <button
-                            key={v}
-                            type="button"
-                            onClick={() => setInput((p) => ({ ...p, rightsItm: v }))}
-                            className={cn(
-                              "rounded-xl border px-3 py-2 text-sm font-medium transition-all",
-                              input.rightsItm === v
-                                ? "border-primary bg-primary/10"
-                                : "border-border bg-background/50",
-                            )}
-                          >
-                            {label}
-                          </button>
-                        ))}
-                      </div>
-                      <label className="mt-4 flex cursor-pointer items-center gap-3 text-sm">
-                        <input
-                          type="checkbox"
-                          checked={input.rightsSubscriptionKnown}
-                          onChange={(e) =>
-                            setInput((p) => ({ ...p, rightsSubscriptionKnown: e.target.checked }))
-                          }
-                          className="size-4 rounded border-border"
-                        />
-                        <span>Subscription price and ratio are known / final</span>
-                      </label>
-                    </fieldset>
-                  )}
-
-                  {input.eventFamily === "merger" && (
-                    <>
-                      <fieldset>
-                        <legend className="mb-3 text-sm font-semibold">M&A — consideration</legend>
-                        <div className="grid grid-cols-1 gap-2 sm:grid-cols-3">
-                          {(
-                            [
-                              ["stock", "Mostly stock"],
-                              ["cash", "Mostly cash"],
-                              ["mixed", "Mixed / unclear"],
-                            ] as const
-                          ).map(([v, label]) => (
-                            <button
-                              key={v}
-                              type="button"
-                              onClick={() => setInput((p) => ({ ...p, mnaDealType: v }))}
-                              className={cn(
-                                "rounded-xl border px-3 py-2 text-sm font-medium transition-all",
-                                input.mnaDealType === v
-                                  ? "border-primary bg-primary/10"
-                                  : "border-border bg-background/50",
-                              )}
-                            >
-                              {label}
-                            </button>
-                          ))}
-                        </div>
-                      </fieldset>
-                      <fieldset>
-                        <legend className="mb-3 text-sm font-semibold">Who is in your managed index?</legend>
-                        <div className="grid grid-cols-1 gap-2 sm:grid-cols-3">
-                          {(
-                            [
-                              ["target_only", "Target only"],
-                              ["acquirer_only", "Acquirer only"],
-                              ["both", "Both in same index"],
-                            ] as const
-                          ).map(([v, label]) => (
-                            <button
-                              key={v}
-                              type="button"
-                              onClick={() => setInput((p) => ({ ...p, mnaIndexParties: v }))}
-                              className={cn(
-                                "rounded-xl border px-3 py-2 text-sm font-medium transition-all",
-                                input.mnaIndexParties === v
-                                  ? "border-primary bg-primary/10"
-                                  : "border-border bg-background/50",
-                              )}
-                            >
-                              {label}
-                            </button>
-                          ))}
-                        </div>
-                      </fieldset>
-                    </>
-                  )}
-
-                  {input.eventFamily === "spinoff" && (
-                    <>
-                      <fieldset>
-                        <legend className="mb-3 text-sm font-semibold">Spin-off child — index eligible?</legend>
-                        <div className="grid grid-cols-1 gap-2 sm:grid-cols-3">
-                          {(
-                            [
-                              ["yes", "Yes — eligible"],
-                              ["no", "No — not eligible"],
-                              ["unknown", "Unknown"],
-                            ] as const
-                          ).map(([v, label]) => (
-                            <button
-                              key={v}
-                              type="button"
-                              onClick={() => setInput((p) => ({ ...p, spinoffChildEligible: v }))}
-                              className={cn(
-                                "rounded-xl border px-3 py-2 text-sm font-medium transition-all",
-                                input.spinoffChildEligible === v
-                                  ? "border-primary bg-primary/10"
-                                  : "border-border bg-background/50",
-                              )}
-                            >
-                              {label}
-                            </button>
-                          ))}
-                        </div>
-                      </fieldset>
-                      {input.spinoffChildEligible !== "no" && (
-                        <fieldset>
-                          <legend className="mb-3 text-sm font-semibold">Trading phase</legend>
-                          <div className="grid grid-cols-1 gap-2 sm:grid-cols-3">
-                            {(
-                              [
-                                ["placeholder", "Placeholder / WI only"],
-                                ["live_trade", "Regular market trading"],
-                                ["unknown", "Unknown"],
-                              ] as const
-                            ).map(([v, label]) => (
-                              <button
-                                key={v}
-                                type="button"
-                                onClick={() => setInput((p) => ({ ...p, spinoffPhase: v }))}
-                                className={cn(
-                                  "rounded-xl border px-3 py-2 text-sm font-medium transition-all",
-                                  input.spinoffPhase === v
-                                    ? "border-primary bg-primary/10"
-                                    : "border-border bg-background/50",
-                                )}
-                              >
-                                {label}
-                              </button>
-                            ))}
-                          </div>
-                        </fieldset>
-                      )}
-                    </>
-                  )}
-
-                  {input.eventFamily === "dividend" && (
-                    <>
-                      <fieldset>
-                        <legend className="mb-3 text-sm font-semibold">Dividend type</legend>
-                        <div className="grid grid-cols-1 gap-2 sm:grid-cols-3">
-                          {(
-                            [
-                              ["ordinary", "Ordinary"],
-                              ["special", "Special"],
-                              ["unknown", "Unknown"],
-                            ] as const
-                          ).map(([v, label]) => (
-                            <button
-                              key={v}
-                              type="button"
-                              onClick={() => setInput((p) => ({ ...p, dividendFlavor: v }))}
-                              className={cn(
-                                "rounded-xl border px-3 py-2 text-sm font-medium transition-all",
-                                input.dividendFlavor === v
-                                  ? "border-primary bg-primary/10"
-                                  : "border-border bg-background/50",
-                              )}
-                            >
-                              {label}
-                            </button>
-                          ))}
-                        </div>
-                      </fieldset>
-                      <fieldset>
-                        <legend className="mb-3 text-sm font-semibold">Index return variant (context)</legend>
-                        <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
-                          {(
-                            [
-                              ["pr", "PR"],
-                              ["tr", "TR"],
-                              ["ntr", "NTR"],
-                              ["unknown", "N/A"],
-                            ] as const
-                          ).map(([v, label]) => (
-                            <button
-                              key={v}
-                              type="button"
-                              onClick={() => setInput((p) => ({ ...p, indexReturnVariant: v }))}
-                              className={cn(
-                                "rounded-xl border px-3 py-2 text-sm font-medium transition-all",
-                                input.indexReturnVariant === v
-                                  ? "border-primary bg-primary/10"
-                                  : "border-border bg-background/50",
-                              )}
-                            >
-                              {label}
-                            </button>
-                          ))}
-                        </div>
-                      </fieldset>
-                    </>
-                  )}
-                </>
-              )}
-            </div>
-          )}
-
-          {step === 2 && (
-            <div className="space-y-4">
-              <div>
-                <label htmlFor="eff-date" className="mb-1.5 block text-sm font-semibold">
-                  Effective date <span className="text-destructive">*</span>
-                </label>
-                <input
-                  id="eff-date"
-                  type="date"
-                  value={input.effectiveDate}
-                  onChange={(e) => setInput((p) => ({ ...p, effectiveDate: e.target.value }))}
-                  className="w-full max-w-xs rounded-xl border border-border bg-background px-3 py-2 text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                  required
-                />
-              </div>
-              <div>
-                <label htmlFor="ex-date" className="mb-1.5 block text-sm font-semibold">
-                  Ex-date <span className="text-muted-foreground font-normal">(optional)</span>
-                </label>
-                <input
-                  id="ex-date"
-                  type="date"
-                  value={input.exDate}
-                  onChange={(e) => setInput((p) => ({ ...p, exDate: e.target.value }))}
-                  className="w-full max-w-xs rounded-xl border border-border bg-background px-3 py-2 text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                />
-              </div>
-              <div>
-                <label htmlFor="asof-date" className="mb-1.5 block text-sm font-semibold">
-                  Projection files as of <span className="text-destructive">*</span>
-                </label>
-                <input
-                  id="asof-date"
-                  type="date"
-                  value={input.dataAsOf}
-                  onChange={(e) => setInput((p) => ({ ...p, dataAsOf: e.target.value }))}
-                  className="w-full max-w-xs rounded-xl border border-border bg-background px-3 py-2 text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                  required
-                />
-                <p className="mt-1 text-xs text-muted-foreground">
-                  Usually “today” for the file drop you are comparing.
-                </p>
-              </div>
-            </div>
-          )}
-
-          {step === 3 && (
-            <div className="space-y-6">
-              <div>
-                <p className="mb-2 text-sm font-semibold">Appears missing (no projection line / empty)</p>
-                <div className="flex flex-wrap gap-2">
-                  {VENDOR_IDS.map((id) => (
-                    <Button
-                      key={`m-${id}`}
-                      type="button"
-                      variant={input.missingVendors.includes(id) ? "default" : "outline"}
-                      size="sm"
-                      onClick={() =>
-                        setInput((p) => ({
-                          ...p,
-                          missingVendors: toggleVendor(p.missingVendors, id),
-                        }))
-                      }
-                    >
-                      {vendorLabel(id)}
-                    </Button>
-                  ))}
-                </div>
-              </div>
-              <div>
-                <p className="mb-2 text-sm font-semibold">Sent projection file as of that date</p>
-                <div className="flex flex-wrap gap-2">
-                  {VENDOR_IDS.map((id) => (
-                    <Button
-                      key={`p-${id}`}
-                      type="button"
-                      variant={input.presentVendors.includes(id) ? "default" : "outline"}
-                      size="sm"
-                      onClick={() =>
-                        setInput((p) => ({
-                          ...p,
-                          presentVendors: toggleVendor(p.presentVendors, id),
-                        }))
-                      }
-                    >
-                      {vendorLabel(id)}
-                    </Button>
-                  ))}
-                </div>
-              </div>
-              <div>
-                <label htmlFor="sim-notes" className="mb-1.5 block text-sm font-semibold">
-                  Notes <span className="text-muted-foreground font-normal">(optional)</span>
-                </label>
-                <textarea
-                  id="sim-notes"
-                  value={input.notes}
-                  onChange={(e) => setInput((p) => ({ ...p, notes: e.target.value.slice(0, 500) }))}
-                  rows={3}
-                  placeholder="Ticker, index name, or other context (shown in summary only)."
-                  className="w-full rounded-xl border border-border bg-background px-3 py-2 text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                />
-                <p className="mt-1 text-xs text-muted-foreground">{input.notes.length}/500</p>
-              </div>
-            </div>
-          )}
-
-          {step === 4 && result && (
-            <div className="space-y-6">
-              <p className="rounded-2xl border border-border bg-background/60 p-4 text-sm leading-relaxed">
-                {result.summary}
-              </p>
-              <ul className="space-y-3">
-                {result.hypotheses.map((h) => (
-                  <li
-                    key={h.id}
+          <p className="mb-1 text-[11px] font-medium uppercase tracking-[0.2em] text-muted-foreground">
+            Guide
+          </p>
+          <h2 id="simulator-heading" className="mb-6 text-lg font-semibold tracking-tight text-foreground sm:text-xl">
+            Projection gap
+          </h2>
+          <ol className="flex flex-row gap-1 overflow-x-auto pb-1 lg:flex-col lg:gap-0 lg:overflow-visible lg:pb-0">
+            {STEP_LABELS.map((label, i) => {
+              const done = i < step || (i === STEP_COUNT - 1 && result !== null);
+              const active = i === step;
+              return (
+                <li key={label} className="min-w-0 shrink-0 lg:min-w-0">
+                  <button
+                    type="button"
+                    onClick={() => goToStep(i)}
                     className={cn(
-                      "rounded-2xl border p-4",
-                      relevanceStyles(h.relevance),
+                      "flex w-full items-start gap-3 rounded-2xl px-3 py-2.5 text-left transition-colors lg:px-3 lg:py-3",
+                      active
+                        ? "bg-foreground/[0.06] text-foreground"
+                        : "text-muted-foreground hover:bg-foreground/[0.04] hover:text-foreground",
                     )}
                   >
-                    <div className="mb-2 flex flex-wrap items-center gap-2">
-                      <span className="text-sm font-bold">{h.title}</span>
-                      <span className="rounded-full border border-current/30 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide">
-                        {h.relevance}
+                    <span
+                      className={cn(
+                        "mt-0.5 flex size-7 shrink-0 items-center justify-center rounded-full text-xs font-semibold",
+                        active
+                          ? "bg-primary text-primary-foreground"
+                          : done
+                            ? "bg-primary/20 text-primary"
+                            : "border border-border bg-background/80 text-muted-foreground",
+                      )}
+                      aria-hidden
+                    >
+                      {done && !active ? <CheckIcon className="size-3.5" /> : i + 1}
+                    </span>
+                    <span className="min-w-0 pt-0.5">
+                      <span className="block text-sm font-medium leading-snug whitespace-normal">
+                        {label}
                       </span>
+                      {i === 1 && (
+                        <span className="mt-0.5 block text-xs leading-snug text-muted-foreground whitespace-normal">
+                          {input.eventCategory === "mandatory" ? "Company-driven" : "Shareholder choice"}
+                        </span>
+                      )}
+                    </span>
+                  </button>
+                </li>
+              );
+            })}
+          </ol>
+        </nav>
+
+        {/* Main panel */}
+        <div className="min-w-0 flex-1">
+          <div className="mb-6">
+            <p className="text-sm leading-relaxed text-muted-foreground">
+              A calm walkthrough — tell us what you are seeing. We will suggest plausible reasons, not vendor rulings.
+            </p>
+          </div>
+
+          <div className="max-h-[min(70vh,640px)] min-h-0 overflow-y-auto overflow-x-hidden pr-1 [-webkit-overflow-scrolling:touch]">
+            <AnimatePresence mode="wait">
+              <motion.div
+                key={step}
+                initial={{ opacity: 0, y: 8 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, y: -6 }}
+                transition={{ duration: 0.22, ease: [0.22, 1, 0.36, 1] }}
+                className="pb-4"
+              >
+                {step === 0 && (
+                  <div className="space-y-4">
+                    <p className="text-base font-medium text-foreground">
+                      What kind of situation is this?
+                    </p>
+                    <p className="text-sm leading-relaxed text-muted-foreground">
+                      This only filters which event types you can pick next — the simulator still infers mandatory vs voluntary from the event itself.
+                    </p>
+                    <div className="grid gap-3 sm:grid-cols-2">
+                      <button
+                        type="button"
+                        onClick={() =>
+                          setInput((p) => {
+                            const eventCategory = "mandatory";
+                            return {
+                              ...p,
+                              eventCategory,
+                              eventFamily: coerceFamilyForCategory(eventCategory, p.eventFamily),
+                            };
+                          })
+                        }
+                        className={cn(
+                          "rounded-3xl border px-5 py-6 text-left transition-all duration-200",
+                          input.eventCategory === "mandatory"
+                            ? "border-primary/40 bg-primary/10 shadow-md ring-1 ring-primary/20"
+                            : "border-border/80 bg-background/40 hover:border-primary/25 hover:bg-background/60",
+                        )}
+                      >
+                        <span className="text-base font-semibold text-foreground">Mandatory</span>
+                        <span className="mt-2 block text-sm leading-relaxed text-muted-foreground">
+                          Dividends, splits, mergers, spin-offs, return of capital, delisting, and similar confirmed actions.
+                        </span>
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() =>
+                          setInput((p) => {
+                            const eventCategory = "voluntary";
+                            return {
+                              ...p,
+                              eventCategory,
+                              eventFamily: coerceFamilyForCategory(eventCategory, p.eventFamily),
+                            };
+                          })
+                        }
+                        className={cn(
+                          "rounded-3xl border px-5 py-6 text-left transition-all duration-200",
+                          input.eventCategory === "voluntary"
+                            ? "border-primary/40 bg-primary/10 shadow-md ring-1 ring-primary/20"
+                            : "border-border/80 bg-background/40 hover:border-primary/25 hover:bg-background/60",
+                        )}
+                      >
+                        <span className="text-base font-semibold text-foreground">Voluntary</span>
+                        <span className="mt-2 block text-sm leading-relaxed text-muted-foreground">
+                          Rights issues, tenders, buybacks — outcomes depend on shareholder participation.
+                        </span>
+                      </button>
                     </div>
-                    <p className="text-sm leading-relaxed opacity-95">{h.explanation}</p>
-                    {h.appliesToVendors.length > 0 && (
-                      <p className="mt-2 text-xs opacity-80">
-                        Most relevant for missing: {h.appliesToVendors.map(vendorLabel).join(", ")}
+                  </div>
+                )}
+
+                {step === 1 && (
+                  <div className="space-y-4">
+                    <p className="text-base font-medium text-foreground">
+                      Which event is it?
+                    </p>
+                    <p className="text-sm text-muted-foreground">
+                      Showing types that match <span className="font-medium text-foreground">{input.eventCategory === "mandatory" ? "mandatory" : "voluntary"}</span> flows.
+                      {impliedClass === "voluntary" ? " Class: voluntary." : " Class: mandatory."}
+                    </p>
+                    <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+                      {allowedFamilies.map((value) => (
+                        <button
+                          key={value}
+                          type="button"
+                          onClick={() => setInput((p) => ({ ...p, eventFamily: value }))}
+                          className={cn(
+                            "rounded-2xl border px-4 py-3.5 text-left text-sm font-medium leading-snug transition-all",
+                            input.eventFamily === value
+                              ? "border-primary/45 bg-primary/12 text-foreground"
+                              : "border-border/70 bg-background/35 text-muted-foreground hover:border-primary/30 hover:text-foreground",
+                          )}
+                        >
+                          {familyLabel(value)}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                )}
+
+                {step === 2 && (
+                  <div className="space-y-8">
+                    <div>
+                      <p className="text-base font-medium text-foreground">Event context</p>
+                      <p className="mt-1 text-sm leading-relaxed text-muted-foreground">
+                        Optional detail helps narrow the story. Skip anything you do not know yet.
                       </p>
+                    </div>
+
+                    {!canShowSubdetails ? (
+                      <p className="rounded-2xl border border-dashed border-border/80 bg-background/30 px-4 py-4 text-sm leading-relaxed text-muted-foreground">
+                        No extra prompts for this event type. Optional numbers below still apply if relevant (for example free-float change around a tender).
+                      </p>
+                    ) : (
+                      <div className="space-y-6">
+                        {input.eventFamily === "rights" && (
+                          <fieldset className="space-y-3">
+                            <legend className="text-sm font-medium text-foreground">Rights</legend>
+                            <div className="flex flex-wrap gap-2">
+                              {(
+                                [
+                                  ["itm", "In the money"],
+                                  ["otm", "Out of the money"],
+                                  ["unknown", "Not sure yet"],
+                                ] as const
+                              ).map(([v, label]) => (
+                                <button
+                                  key={v}
+                                  type="button"
+                                  onClick={() => setInput((p) => ({ ...p, rightsItm: v }))}
+                                  className={cn(
+                                    "rounded-full border px-4 py-2 text-sm transition-all",
+                                    input.rightsItm === v
+                                      ? "border-primary/50 bg-primary/15 text-foreground"
+                                      : "border-border bg-background/50 text-muted-foreground hover:text-foreground",
+                                  )}
+                                >
+                                  {label}
+                                </button>
+                              ))}
+                            </div>
+                            <label className="flex cursor-pointer items-start gap-3 rounded-2xl border border-border/60 bg-background/30 px-4 py-3 text-sm">
+                              <input
+                                type="checkbox"
+                                checked={input.rightsSubscriptionKnown}
+                                onChange={(e) =>
+                                  setInput((p) => ({ ...p, rightsSubscriptionKnown: e.target.checked }))
+                                }
+                                className="mt-0.5 size-4 rounded border-border"
+                              />
+                              <span className="leading-snug">Final subscription price and ratio are known.</span>
+                            </label>
+                          </fieldset>
+                        )}
+
+                        {input.eventFamily === "merger" && (
+                          <div className="space-y-5">
+                            <fieldset className="space-y-3">
+                              <legend className="text-sm font-medium text-foreground">Deal</legend>
+                              <div className="flex flex-wrap gap-2">
+                                {(
+                                  [
+                                    ["stock", "Mostly stock"],
+                                    ["cash", "Mostly cash"],
+                                    ["mixed", "Mixed or unclear"],
+                                  ] as const
+                                ).map(([v, label]) => (
+                                  <button
+                                    key={v}
+                                    type="button"
+                                    onClick={() => setInput((p) => ({ ...p, mnaDealType: v }))}
+                                    className={cn(
+                                      "rounded-full border px-4 py-2 text-sm transition-all",
+                                      input.mnaDealType === v
+                                        ? "border-primary/50 bg-primary/15 text-foreground"
+                                        : "border-border bg-background/50 text-muted-foreground hover:text-foreground",
+                                    )}
+                                  >
+                                    {label}
+                                  </button>
+                                ))}
+                              </div>
+                            </fieldset>
+                            <fieldset className="space-y-3">
+                              <legend className="text-sm font-medium text-foreground">Index membership</legend>
+                              <div className="flex flex-wrap gap-2">
+                                {(
+                                  [
+                                    ["target_only", "Target only"],
+                                    ["acquirer_only", "Acquirer only"],
+                                    ["both", "Both in the same index"],
+                                  ] as const
+                                ).map(([v, label]) => (
+                                  <button
+                                    key={v}
+                                    type="button"
+                                    onClick={() => setInput((p) => ({ ...p, mnaIndexParties: v }))}
+                                    className={cn(
+                                      "rounded-full border px-4 py-2 text-sm transition-all",
+                                      input.mnaIndexParties === v
+                                        ? "border-primary/50 bg-primary/15 text-foreground"
+                                        : "border-border bg-background/50 text-muted-foreground hover:text-foreground",
+                                    )}
+                                  >
+                                    {label}
+                                  </button>
+                                ))}
+                              </div>
+                            </fieldset>
+                          </div>
+                        )}
+
+                        {input.eventFamily === "spinoff" && (
+                          <div className="space-y-5">
+                            <fieldset className="space-y-3">
+                              <legend className="text-sm font-medium text-foreground">Spin-off child</legend>
+                              <div className="flex flex-wrap gap-2">
+                                {(
+                                  [
+                                    ["yes", "Eligible for the index"],
+                                    ["no", "Not eligible"],
+                                    ["unknown", "Unknown"],
+                                  ] as const
+                                ).map(([v, label]) => (
+                                  <button
+                                    key={v}
+                                    type="button"
+                                    onClick={() => setInput((p) => ({ ...p, spinoffChildEligible: v }))}
+                                    className={cn(
+                                      "rounded-full border px-4 py-2 text-sm transition-all",
+                                      input.spinoffChildEligible === v
+                                        ? "border-primary/50 bg-primary/15 text-foreground"
+                                        : "border-border bg-background/50 text-muted-foreground hover:text-foreground",
+                                    )}
+                                  >
+                                    {label}
+                                  </button>
+                                ))}
+                              </div>
+                            </fieldset>
+                            {input.spinoffChildEligible !== "no" && (
+                              <fieldset className="space-y-3">
+                                <legend className="text-sm font-medium text-foreground">Trading</legend>
+                                <div className="flex flex-wrap gap-2">
+                                  {(
+                                    [
+                                      ["placeholder", "Placeholder or when-issued only"],
+                                      ["live_trade", "Regular market trading"],
+                                      ["unknown", "Unknown"],
+                                    ] as const
+                                  ).map(([v, label]) => (
+                                    <button
+                                      key={v}
+                                      type="button"
+                                      onClick={() => setInput((p) => ({ ...p, spinoffPhase: v }))}
+                                      className={cn(
+                                        "rounded-full border px-4 py-2 text-sm transition-all",
+                                        input.spinoffPhase === v
+                                          ? "border-primary/50 bg-primary/15 text-foreground"
+                                          : "border-border bg-background/50 text-muted-foreground hover:text-foreground",
+                                      )}
+                                    >
+                                      {label}
+                                    </button>
+                                  ))}
+                                </div>
+                              </fieldset>
+                            )}
+                          </div>
+                        )}
+
+                        {input.eventFamily === "dividend" && (
+                          <div className="space-y-5">
+                            <fieldset className="space-y-3">
+                              <legend className="text-sm font-medium text-foreground">Dividend</legend>
+                              <div className="flex flex-wrap gap-2">
+                                {(
+                                  [
+                                    ["ordinary", "Ordinary"],
+                                    ["special", "Special"],
+                                    ["unknown", "Unknown"],
+                                  ] as const
+                                ).map(([v, label]) => (
+                                  <button
+                                    key={v}
+                                    type="button"
+                                    onClick={() => setInput((p) => ({ ...p, dividendFlavor: v }))}
+                                    className={cn(
+                                      "rounded-full border px-4 py-2 text-sm transition-all",
+                                      input.dividendFlavor === v
+                                        ? "border-primary/50 bg-primary/15 text-foreground"
+                                        : "border-border bg-background/50 text-muted-foreground hover:text-foreground",
+                                    )}
+                                  >
+                                    {label}
+                                  </button>
+                                ))}
+                              </div>
+                            </fieldset>
+                            <fieldset className="space-y-3">
+                              <legend className="text-sm font-medium text-foreground">Index variant you are comparing</legend>
+                              <div className="flex flex-wrap gap-2">
+                                {(
+                                  [
+                                    ["pr", "PR"],
+                                    ["tr", "TR"],
+                                    ["ntr", "NTR"],
+                                    ["unknown", "Not applicable"],
+                                  ] as const
+                                ).map(([v, label]) => (
+                                  <button
+                                    key={v}
+                                    type="button"
+                                    onClick={() => setInput((p) => ({ ...p, indexReturnVariant: v }))}
+                                    className={cn(
+                                      "rounded-full border px-4 py-2 text-sm transition-all",
+                                      input.indexReturnVariant === v
+                                        ? "border-primary/50 bg-primary/15 text-foreground"
+                                        : "border-border bg-background/50 text-muted-foreground hover:text-foreground",
+                                    )}
+                                  >
+                                    {label}
+                                  </button>
+                                ))}
+                              </div>
+                            </fieldset>
+                          </div>
+                        )}
+                      </div>
                     )}
-                  </li>
-                ))}
-              </ul>
-              <div>
-                <p className="mb-2 text-sm font-semibold">Next steps</p>
-                <div className="flex flex-wrap gap-2">
-                  {result.nextStepLinks.map((l) => (
-                    <Button key={l.href} variant="secondary" size="sm" nativeButton={false} render={<Link href={l.href} />}>
-                      {l.label}
-                    </Button>
-                  ))}
-                </div>
-              </div>
-              <p className="text-xs leading-relaxed text-muted-foreground">{result.disclaimer}</p>
-              <p className="text-[10px] text-muted-foreground">Simulator rules v{result.rulesVersion}</p>
-            </div>
-          )}
-        </motion.div>
-      </AnimatePresence>
 
-      {stepError && (
-        <p className="mt-3 text-sm text-destructive" role="alert">
-          {stepError}
-        </p>
-      )}
+                    <div className="rounded-3xl border border-border/60 bg-background/25 p-5 sm:p-6">
+                      <p className="text-sm font-medium text-foreground">Optional numbers</p>
+                      <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
+                        Rough percentages are fine. Leave blank if unknown — the simulator will ignore that signal.
+                      </p>
+                      <div className="mt-4 grid gap-4 sm:grid-cols-2">
+                        <label className="block space-y-1.5">
+                          <span className="text-xs font-medium text-muted-foreground">
+                            Dividend yield (% of price)
+                          </span>
+                          <input
+                            type="text"
+                            inputMode="decimal"
+                            placeholder="e.g. 5"
+                            value={input.metrics.dividendYieldPct}
+                            onChange={(e) =>
+                              setInput((p) => ({
+                                ...p,
+                                metrics: { ...p.metrics, dividendYieldPct: e.target.value },
+                              }))
+                            }
+                            className="w-full rounded-xl border border-border bg-background px-3 py-2.5 text-sm outline-none ring-0 transition-shadow focus-visible:border-primary/50 focus-visible:shadow-[0_0_0_3px_oklch(0.72_0.19_250/0.25)]"
+                          />
+                        </label>
+                        <label className="block space-y-1.5">
+                          <span className="text-xs font-medium text-muted-foreground">
+                            Free-float change (points)
+                          </span>
+                          <input
+                            type="text"
+                            inputMode="decimal"
+                            placeholder="e.g. 6 or -3"
+                            value={input.metrics.freeFloatChangePp}
+                            onChange={(e) =>
+                              setInput((p) => ({
+                                ...p,
+                                metrics: { ...p.metrics, freeFloatChangePp: e.target.value },
+                              }))
+                            }
+                            className="w-full rounded-xl border border-border bg-background px-3 py-2.5 text-sm outline-none focus-visible:border-primary/50 focus-visible:shadow-[0_0_0_3px_oklch(0.72_0.19_250/0.25)]"
+                          />
+                        </label>
+                        <label className="block space-y-1.5">
+                          <span className="text-xs font-medium text-muted-foreground">
+                            Tender acceptance (%)
+                          </span>
+                          <input
+                            type="text"
+                            inputMode="decimal"
+                            placeholder="e.g. 72"
+                            value={input.metrics.tenderAcceptancePct}
+                            onChange={(e) =>
+                              setInput((p) => ({
+                                ...p,
+                                metrics: { ...p.metrics, tenderAcceptancePct: e.target.value },
+                              }))
+                            }
+                            className="w-full rounded-xl border border-border bg-background px-3 py-2.5 text-sm outline-none focus-visible:border-primary/50 focus-visible:shadow-[0_0_0_3px_oklch(0.72_0.19_250/0.25)]"
+                          />
+                        </label>
+                        <label className="block space-y-1.5">
+                          <span className="text-xs font-medium text-muted-foreground">
+                            Rights discount vs theoretical (%)
+                          </span>
+                          <input
+                            type="text"
+                            inputMode="decimal"
+                            placeholder="e.g. 15"
+                            value={input.metrics.rightsDiscountPct}
+                            onChange={(e) =>
+                              setInput((p) => ({
+                                ...p,
+                                metrics: { ...p.metrics, rightsDiscountPct: e.target.value },
+                              }))
+                            }
+                            className="w-full rounded-xl border border-border bg-background px-3 py-2.5 text-sm outline-none focus-visible:border-primary/50 focus-visible:shadow-[0_0_0_3px_oklch(0.72_0.19_250/0.25)]"
+                          />
+                        </label>
+                      </div>
+                    </div>
+                  </div>
+                )}
 
-      <div className="mt-8 flex flex-col-reverse gap-3 border-t border-border pt-6 sm:flex-row sm:items-center sm:justify-between">
-        <div className="flex gap-2">
-          {step > 0 && step < 4 && (
-            <Button type="button" variant="outline" size="default" onClick={goBack}>
-              <ArrowLeftIcon data-icon="inline-start" className="size-4" />
-              Back
-            </Button>
+                {step === 3 && (
+                  <div className="max-w-lg space-y-5">
+                    <p className="text-base font-medium text-foreground">Dates</p>
+                    <label className="block space-y-2">
+                      <span className="text-sm font-medium text-foreground">Effective date</span>
+                      <input
+                        type="date"
+                        value={input.effectiveDate}
+                        onChange={(e) => setInput((p) => ({ ...p, effectiveDate: e.target.value }))}
+                        className="w-full rounded-xl border border-border bg-background px-3 py-2.5 text-sm outline-none focus-visible:border-primary/50 focus-visible:shadow-[0_0_0_3px_oklch(0.72_0.19_250/0.25)]"
+                      />
+                    </label>
+                    <label className="block space-y-2">
+                      <span className="text-sm font-medium text-foreground">
+                        Ex-date <span className="font-normal text-muted-foreground">(optional)</span>
+                      </span>
+                      <input
+                        type="date"
+                        value={input.exDate}
+                        onChange={(e) => setInput((p) => ({ ...p, exDate: e.target.value }))}
+                        className="w-full rounded-xl border border-border bg-background px-3 py-2.5 text-sm outline-none focus-visible:border-primary/50 focus-visible:shadow-[0_0_0_3px_oklch(0.72_0.19_250/0.25)]"
+                      />
+                    </label>
+                    <label className="block space-y-2">
+                      <span className="text-sm font-medium text-foreground">Projection files as of</span>
+                      <input
+                        type="date"
+                        value={input.dataAsOf}
+                        onChange={(e) => setInput((p) => ({ ...p, dataAsOf: e.target.value }))}
+                        className="w-full rounded-xl border border-border bg-background px-3 py-2.5 text-sm outline-none focus-visible:border-primary/50 focus-visible:shadow-[0_0_0_3px_oklch(0.72_0.19_250/0.25)]"
+                      />
+                      <span className="text-xs leading-relaxed text-muted-foreground">
+                        Usually the date of the file drop you are comparing.
+                      </span>
+                    </label>
+                  </div>
+                )}
+
+                {step === 4 && (
+                  <div className="space-y-6">
+                    <p className="text-base font-medium text-foreground">Vendor picture</p>
+                    <div className="grid gap-6 sm:grid-cols-2">
+                      <div className="rounded-2xl border border-border/70 bg-background/30 p-4">
+                        <p className="mb-3 text-sm font-medium text-foreground">Looks missing or empty</p>
+                        <div className="flex flex-wrap gap-2">
+                          {VENDOR_IDS.map((id) => (
+                            <button
+                              key={`m-${id}`}
+                              type="button"
+                              onClick={() =>
+                                setInput((p) => ({
+                                  ...p,
+                                  missingVendors: toggleVendor(p.missingVendors, id),
+                                }))
+                              }
+                              className={cn(
+                                "rounded-full border px-3 py-1.5 text-xs font-medium transition-all sm:text-sm",
+                                input.missingVendors.includes(id)
+                                  ? "border-primary/50 bg-primary/20 text-foreground"
+                                  : "border-border/80 bg-background/60 text-muted-foreground hover:border-primary/30",
+                              )}
+                            >
+                              {vendorLabel(id)}
+                            </button>
+                          ))}
+                        </div>
+                      </div>
+                      <div className="rounded-2xl border border-border/70 bg-background/30 p-4">
+                        <p className="mb-3 text-sm font-medium text-foreground">Already in the file</p>
+                        <div className="flex flex-wrap gap-2">
+                          {VENDOR_IDS.map((id) => (
+                            <button
+                              key={`p-${id}`}
+                              type="button"
+                              onClick={() =>
+                                setInput((p) => ({
+                                  ...p,
+                                  presentVendors: toggleVendor(p.presentVendors, id),
+                                }))
+                              }
+                              className={cn(
+                                "rounded-full border px-3 py-1.5 text-xs font-medium transition-all sm:text-sm",
+                                input.presentVendors.includes(id)
+                                  ? "border-primary/50 bg-primary/20 text-foreground"
+                                  : "border-border/80 bg-background/60 text-muted-foreground hover:border-primary/30",
+                              )}
+                            >
+                              {vendorLabel(id)}
+                            </button>
+                          ))}
+                        </div>
+                      </div>
+                    </div>
+                    <label className="block space-y-2">
+                      <span className="text-sm font-medium text-foreground">
+                        Short notes <span className="font-normal text-muted-foreground">(optional)</span>
+                      </span>
+                      <textarea
+                        value={input.notes}
+                        onChange={(e) => setInput((p) => ({ ...p, notes: e.target.value.slice(0, 500) }))}
+                        rows={3}
+                        placeholder="Ticker, index, or anything else you want echoed in the summary."
+                        className="w-full resize-y rounded-2xl border border-border bg-background px-3 py-2.5 text-sm outline-none focus-visible:border-primary/50 focus-visible:shadow-[0_0_0_3px_oklch(0.72_0.19_250/0.25)]"
+                      />
+                      <span className="text-xs text-muted-foreground">{input.notes.length} / 500</span>
+                    </label>
+                  </div>
+                )}
+
+                {step === 5 && result && (
+                  <div className="space-y-6">
+                    <p className="rounded-2xl border border-border/60 bg-background/40 px-4 py-4 text-sm leading-relaxed text-foreground">
+                      {result.summary}
+                    </p>
+                    <ul className="space-y-3">
+                      {result.hypotheses.map((h) => (
+                        <li
+                          key={h.id}
+                          className={cn(
+                            "rounded-2xl border p-4 sm:p-5",
+                            relevanceTone(h.relevance),
+                          )}
+                        >
+                          <div className="mb-2 flex flex-wrap items-baseline gap-2 gap-y-1">
+                            <span className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+                              {h.relevance} likelihood
+                            </span>
+                          </div>
+                          <p className="text-base font-semibold leading-snug text-foreground">{h.title}</p>
+                          <p className="mt-2 text-sm leading-relaxed text-muted-foreground">{h.explanation}</p>
+                          {h.appliesToVendors.length > 0 && (
+                            <p className="mt-3 text-xs leading-relaxed text-muted-foreground">
+                              Most relevant where missing:{" "}
+                              <span className="font-medium text-foreground">
+                                {h.appliesToVendors.map(vendorLabel).join(", ")}
+                              </span>
+                            </p>
+                          )}
+                        </li>
+                      ))}
+                    </ul>
+                    <div>
+                      <p className="mb-2 text-sm font-medium text-foreground">Dig deeper</p>
+                      <div className="flex flex-wrap gap-2">
+                        {result.nextStepLinks.map((l) => (
+                          <Button
+                            key={l.href}
+                            variant="secondary"
+                            size="sm"
+                            nativeButton={false}
+                            render={<Link href={l.href} />}
+                          >
+                            {l.label}
+                          </Button>
+                        ))}
+                      </div>
+                    </div>
+                    <p className="text-xs leading-relaxed text-muted-foreground">{result.disclaimer}</p>
+                    <p className="text-[11px] text-muted-foreground">Rules version {result.rulesVersion}</p>
+                  </div>
+                )}
+              </motion.div>
+            </AnimatePresence>
+          </div>
+
+          {stepError && (
+            <p className="mt-4 text-sm text-destructive" role="alert">
+              {stepError}
+            </p>
           )}
-          {step === 4 && (
-            <Button type="button" variant="outline" onClick={reset}>
-              Start over
-            </Button>
-          )}
-        </div>
-        <div className="flex gap-2 sm:ml-auto">
-          {step < 4 ? (
-            <Button type="button" onClick={goNext}>
-              {step === 3 ? (
-                <>
-                  Run simulation
-                  <SparklesIcon data-icon="inline-end" className="size-4" />
-                </>
-              ) : (
-                <>
-                  Continue
-                  <ArrowRightIcon data-icon="inline-end" className="size-4" />
-                </>
+
+          <div className="mt-6 flex flex-col-reverse gap-3 border-t border-border/50 pt-6 sm:flex-row sm:items-center sm:justify-between">
+            <div className="flex flex-wrap gap-2">
+              {step > 0 && (
+                <Button type="button" variant="outline" size="default" onClick={goBack}>
+                  <ArrowLeftIcon data-icon="inline-start" className="size-4" />
+                  Back
+                </Button>
               )}
-            </Button>
-          ) : null}
+              {step === STEP_COUNT - 1 && (
+                <Button type="button" variant="ghost" onClick={reset}>
+                  Start over
+                </Button>
+              )}
+            </div>
+            <div className="flex gap-2 sm:ml-auto">
+              {step < STEP_COUNT - 1 ? (
+                <Button type="button" onClick={goNext}>
+                  {step === STEP_COUNT - 2 ? (
+                    "See possible reasons"
+                  ) : (
+                    <>
+                      Continue
+                      <ArrowRightIcon data-icon="inline-end" className="size-4" />
+                    </>
+                  )}
+                </Button>
+              ) : (
+                <Button type="button" variant="outline" onClick={() => goToStep(STEP_COUNT - 2)}>
+                  Edit answers
+                </Button>
+              )}
+            </div>
+          </div>
         </div>
       </div>
     </section>

--- a/src/components/projection-gap-simulator.tsx
+++ b/src/components/projection-gap-simulator.tsx
@@ -699,10 +699,13 @@ export function ProjectionGapSimulator() {
                 {step === 4 && (
                   <div className="space-y-6">
                     <p className="text-base font-medium text-foreground">Vendor picture</p>
-                    <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
-                      <div className="rounded-2xl border border-border/70 bg-background/30 p-4">
-                        <p className="mb-3 text-sm font-medium text-foreground">Looks missing or empty</p>
-                        <div className="flex flex-wrap gap-2">
+                    {/* One column until xl so narrow hero columns do not split ~94px tracks; min-w-0 fixes grid/flex overflow */}
+                    <div className="grid min-w-0 grid-cols-1 gap-6 xl:grid-cols-2">
+                      <div className="min-w-0 overflow-hidden rounded-2xl border border-border/70 bg-background/30 p-4 sm:p-5">
+                        <p className="mb-3 text-pretty text-sm font-medium leading-snug text-foreground">
+                          Missing or empty in the feed
+                        </p>
+                        <div className="flex min-w-0 flex-wrap gap-2">
                           {VENDOR_IDS.map((id) => (
                             <button
                               key={`m-${id}`}
@@ -714,7 +717,7 @@ export function ProjectionGapSimulator() {
                                 }))
                               }
                               className={cn(
-                                "rounded-full border px-3 py-1.5 text-xs font-medium transition-all sm:text-sm",
+                                "inline-flex min-h-9 min-w-0 max-w-full shrink break-words rounded-2xl border px-3 py-2 text-center text-xs font-medium leading-snug transition-all sm:text-sm",
                                 input.missingVendors.includes(id)
                                   ? "border-primary/50 bg-primary/20 text-foreground"
                                   : "border-border/80 bg-background/60 text-muted-foreground hover:border-primary/30",
@@ -725,9 +728,11 @@ export function ProjectionGapSimulator() {
                           ))}
                         </div>
                       </div>
-                      <div className="rounded-2xl border border-border/70 bg-background/30 p-4">
-                        <p className="mb-3 text-sm font-medium text-foreground">Already in the file</p>
-                        <div className="flex flex-wrap gap-2">
+                      <div className="min-w-0 overflow-hidden rounded-2xl border border-border/70 bg-background/30 p-4 sm:p-5">
+                        <p className="mb-3 text-pretty text-sm font-medium leading-snug text-foreground">
+                          Already in the projection file
+                        </p>
+                        <div className="flex min-w-0 flex-wrap gap-2">
                           {VENDOR_IDS.map((id) => (
                             <button
                               key={`p-${id}`}
@@ -739,7 +744,7 @@ export function ProjectionGapSimulator() {
                                 }))
                               }
                               className={cn(
-                                "rounded-full border px-3 py-1.5 text-xs font-medium transition-all sm:text-sm",
+                                "inline-flex min-h-9 min-w-0 max-w-full shrink break-words rounded-2xl border px-3 py-2 text-center text-xs font-medium leading-snug transition-all sm:text-sm",
                                 input.presentVendors.includes(id)
                                   ? "border-primary/50 bg-primary/20 text-foreground"
                                   : "border-border/80 bg-background/60 text-muted-foreground hover:border-primary/30",

--- a/src/components/projection-gap-simulator.tsx
+++ b/src/components/projection-gap-simulator.tsx
@@ -171,16 +171,16 @@ export function ProjectionGapSimulator() {
   return (
     <section
       id="projection-gap-simulator"
-      className="relative overflow-hidden rounded-[2rem] border border-white/10 bg-gradient-to-br from-card/95 via-card/90 to-primary/5 p-5 shadow-2xl shadow-black/25 ring-1 ring-white/5 sm:p-8 md:p-10"
+      className="relative w-full max-w-full min-w-0 overflow-hidden rounded-[2rem] border border-white/10 bg-gradient-to-br from-card/95 via-card/90 to-primary/5 p-5 shadow-2xl shadow-black/25 ring-1 ring-white/5 sm:p-8 md:p-10"
       aria-labelledby="simulator-heading"
     >
       <div className="pointer-events-none absolute -right-24 -top-24 size-72 rounded-full bg-primary/15 blur-3xl" aria-hidden />
       <div className="pointer-events-none absolute -bottom-32 -left-16 size-64 rounded-full bg-foreground/5 blur-3xl" aria-hidden />
 
-      <div className="relative flex flex-col gap-8 lg:flex-row lg:gap-10">
+      <div className="relative flex min-w-0 flex-col gap-8 lg:flex-row lg:gap-10">
         {/* Step rail — full labels, no truncation */}
         <nav
-          className="shrink-0 lg:w-52"
+          className="min-w-0 shrink-0 lg:w-52"
           aria-label="Simulator steps"
         >
           <p className="mb-1 text-[11px] font-medium uppercase tracking-[0.2em] text-muted-foreground">
@@ -236,14 +236,14 @@ export function ProjectionGapSimulator() {
         </nav>
 
         {/* Main panel */}
-        <div className="min-w-0 flex-1">
+        <div className="min-w-0 w-full max-w-full flex-1">
           <div className="mb-6">
             <p className="text-sm leading-relaxed text-muted-foreground">
               A calm walkthrough — tell us what you are seeing. We will suggest plausible reasons, not vendor rulings.
             </p>
           </div>
 
-          <div className="max-h-[min(70vh,640px)] min-h-0 overflow-y-auto overflow-x-hidden pr-1 [-webkit-overflow-scrolling:touch]">
+          <div className="max-h-[min(70vh,640px)] min-h-0 min-w-0 overflow-y-auto overflow-x-auto pr-1 [-webkit-overflow-scrolling:touch]">
             <AnimatePresence mode="wait">
               <motion.div
                 key={step}
@@ -261,7 +261,7 @@ export function ProjectionGapSimulator() {
                     <p className="text-sm leading-relaxed text-muted-foreground">
                       This only filters which event types you can pick next — the simulator still infers mandatory vs voluntary from the event itself.
                     </p>
-                    <div className="grid gap-3 sm:grid-cols-2">
+                    <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
                       <button
                         type="button"
                         onClick={() =>
@@ -275,14 +275,14 @@ export function ProjectionGapSimulator() {
                           })
                         }
                         className={cn(
-                          "rounded-3xl border px-5 py-6 text-left transition-all duration-200",
+                          "min-w-0 rounded-3xl border px-5 py-6 text-left transition-all duration-200",
                           input.eventCategory === "mandatory"
                             ? "border-primary/40 bg-primary/10 shadow-md ring-1 ring-primary/20"
                             : "border-border/80 bg-background/40 hover:border-primary/25 hover:bg-background/60",
                         )}
                       >
                         <span className="text-base font-semibold text-foreground">Mandatory</span>
-                        <span className="mt-2 block text-sm leading-relaxed text-muted-foreground">
+                        <span className="mt-2 block text-pretty text-sm leading-relaxed text-muted-foreground">
                           Dividends, splits, mergers, spin-offs, return of capital, delisting, and similar confirmed actions.
                         </span>
                       </button>
@@ -299,14 +299,14 @@ export function ProjectionGapSimulator() {
                           })
                         }
                         className={cn(
-                          "rounded-3xl border px-5 py-6 text-left transition-all duration-200",
+                          "min-w-0 rounded-3xl border px-5 py-6 text-left transition-all duration-200",
                           input.eventCategory === "voluntary"
                             ? "border-primary/40 bg-primary/10 shadow-md ring-1 ring-primary/20"
                             : "border-border/80 bg-background/40 hover:border-primary/25 hover:bg-background/60",
                         )}
                       >
                         <span className="text-base font-semibold text-foreground">Voluntary</span>
-                        <span className="mt-2 block text-sm leading-relaxed text-muted-foreground">
+                        <span className="mt-2 block text-pretty text-sm leading-relaxed text-muted-foreground">
                           Rights issues, tenders, buybacks — outcomes depend on shareholder participation.
                         </span>
                       </button>
@@ -323,7 +323,7 @@ export function ProjectionGapSimulator() {
                       Showing types that match <span className="font-medium text-foreground">{input.eventCategory === "mandatory" ? "mandatory" : "voluntary"}</span> flows.
                       {impliedClass === "voluntary" ? " Class: voluntary." : " Class: mandatory."}
                     </p>
-                    <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+                    <div className="grid grid-cols-1 gap-2 md:grid-cols-2">
                       {allowedFamilies.map((value) => (
                         <button
                           key={value}
@@ -579,7 +579,7 @@ export function ProjectionGapSimulator() {
                       <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
                         Rough percentages are fine. Leave blank if unknown — the simulator will ignore that signal.
                       </p>
-                      <div className="mt-4 grid gap-4 sm:grid-cols-2">
+                      <div className="mt-4 grid grid-cols-1 gap-4 md:grid-cols-2">
                         <label className="block space-y-1.5">
                           <span className="text-xs font-medium text-muted-foreground">
                             Dividend yield (% of price)
@@ -698,7 +698,7 @@ export function ProjectionGapSimulator() {
                 {step === 4 && (
                   <div className="space-y-6">
                     <p className="text-base font-medium text-foreground">Vendor picture</p>
-                    <div className="grid gap-6 sm:grid-cols-2">
+                    <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
                       <div className="rounded-2xl border border-border/70 bg-background/30 p-4">
                         <p className="mb-3 text-sm font-medium text-foreground">Looks missing or empty</p>
                         <div className="flex flex-wrap gap-2">

--- a/src/components/projection-gap-simulator.tsx
+++ b/src/components/projection-gap-simulator.tsx
@@ -1,0 +1,657 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import Link from "next/link";
+import { AnimatePresence, motion } from "framer-motion";
+import { ArrowLeftIcon, ArrowRightIcon, SparklesIcon } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { VENDOR_IDS, vendorLabel, type VendorId } from "@/lib/vendors";
+import { runSimulator } from "@/lib/simulator/simulator-engine";
+import type { SimulatorInput, SimulatorResult } from "@/lib/simulator/types";
+
+const STEPS = [
+  "Event",
+  "Details",
+  "Dates",
+  "Vendors",
+  "Results",
+] as const;
+
+function todayIso(): string {
+  const d = new Date();
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+const defaultInput = (): SimulatorInput => ({
+  eventClass: "mandatory",
+  eventFamily: "merger",
+  rightsItm: "unknown",
+  rightsSubscriptionKnown: true,
+  mnaDealType: "stock",
+  mnaIndexParties: "both",
+  spinoffChildEligible: "unknown",
+  spinoffPhase: "unknown",
+  dividendFlavor: "unknown",
+  indexReturnVariant: "unknown",
+  effectiveDate: "",
+  exDate: "",
+  dataAsOf: todayIso(),
+  missingVendors: [],
+  presentVendors: [],
+  notes: "",
+});
+
+function relevanceStyles(r: "high" | "medium" | "low"): string {
+  if (r === "high") return "border-primary/40 bg-primary/10 text-primary";
+  if (r === "medium") return "border-amber-500/30 bg-amber-500/10 text-amber-200";
+  return "border-border bg-muted/30 text-muted-foreground";
+}
+
+function toggleVendor(list: VendorId[], id: VendorId): VendorId[] {
+  return list.includes(id) ? list.filter((x) => x !== id) : [...list, id];
+}
+
+export function ProjectionGapSimulator() {
+  const [step, setStep] = useState(0);
+  const [input, setInput] = useState<SimulatorInput>(defaultInput);
+  const [result, setResult] = useState<SimulatorResult | null>(null);
+  const [stepError, setStepError] = useState<string | null>(null);
+
+  const canShowSubdetails = useMemo(() => {
+    const f = input.eventFamily;
+    return (
+      f === "rights" ||
+      f === "merger" ||
+      f === "spinoff" ||
+      f === "dividend"
+    );
+  }, [input.eventFamily]);
+
+  function validateCurrent(): string | null {
+    if (step === 0) return null;
+    if (step === 1) {
+      return null;
+    }
+    if (step === 2) {
+      if (!input.effectiveDate) return "Please set an effective date.";
+      if (!input.dataAsOf) return "Please set the projection “as of” date.";
+      return null;
+    }
+    if (step === 3) {
+      if (input.missingVendors.length === 0 || input.presentVendors.length === 0) {
+        return "Select at least one vendor that appears missing and at least one that sent a projection file.";
+      }
+      return null;
+    }
+    return null;
+  }
+
+  function goNext() {
+    const err = validateCurrent();
+    if (err) {
+      setStepError(err);
+      return;
+    }
+    setStepError(null);
+    if (step === 3) {
+      setResult(runSimulator(input));
+      setStep(4);
+      return;
+    }
+    setStep((s) => Math.min(s + 1, STEPS.length - 1));
+  }
+
+  function goBack() {
+    setStepError(null);
+    setStep((s) => Math.max(s - 1, 0));
+  }
+
+  function reset() {
+    setInput(defaultInput());
+    setResult(null);
+    setStep(0);
+    setStepError(null);
+  }
+
+  return (
+    <section
+      id="projection-gap-simulator"
+      className="relative mx-auto max-w-3xl rounded-3xl border border-border bg-card/80 p-6 shadow-xl shadow-black/20 backdrop-blur-md md:p-8"
+      aria-labelledby="simulator-heading"
+    >
+      <div className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <div className="mb-2 inline-flex items-center gap-2 rounded-full border border-primary/30 bg-primary/10 px-3 py-1 text-xs font-medium text-primary">
+            <SparklesIcon className="size-3.5" aria-hidden />
+            Interactive
+          </div>
+          <h2 id="simulator-heading" className="text-xl font-bold tracking-tight md:text-2xl">
+            Projection gap simulator
+          </h2>
+          <p className="mt-1 max-w-xl text-sm text-muted-foreground">
+            Describe the event, dates, and which vendors differ. You will get ranked, explainable hypotheses — not vendor guarantees.
+          </p>
+        </div>
+        <div className="flex shrink-0 gap-1 rounded-xl border border-border bg-background/80 p-1">
+          {STEPS.map((label, i) => (
+            <div
+              key={label}
+              className={cn(
+                "flex min-w-0 flex-1 items-center justify-center rounded-lg px-2 py-1.5 text-center text-[10px] font-semibold uppercase tracking-wide sm:text-xs",
+                i === step
+                  ? "bg-primary text-primary-foreground"
+                  : i < step
+                    ? "text-muted-foreground"
+                    : "text-muted-foreground/60",
+              )}
+              title={label}
+            >
+              <span className="truncate">{label}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <AnimatePresence mode="wait">
+        <motion.div
+          key={step}
+          initial={{ opacity: 0, x: 12 }}
+          animate={{ opacity: 1, x: 0 }}
+          exit={{ opacity: 0, x: -12 }}
+          transition={{ duration: 0.2 }}
+          className="min-h-[220px]"
+        >
+          {step === 0 && (
+            <div className="space-y-6">
+              <fieldset>
+                <legend className="mb-3 text-sm font-semibold">Event class</legend>
+                <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+                  {(
+                    [
+                      { v: "mandatory" as const, t: "Mandatory", d: "Confirmed facts — dividend, split, merger, spin-off…" },
+                      { v: "voluntary" as const, t: "Voluntary", d: "Shareholder choice — rights, tender, partial offer…" },
+                    ] as const
+                  ).map((o) => (
+                    <button
+                      key={o.v}
+                      type="button"
+                      onClick={() => setInput((p) => ({ ...p, eventClass: o.v }))}
+                      className={cn(
+                        "rounded-2xl border p-4 text-left text-sm transition-all hover:border-primary/50",
+                        input.eventClass === o.v
+                          ? "border-primary bg-primary/10"
+                          : "border-border bg-background/50",
+                      )}
+                    >
+                      <div className="font-semibold">{o.t}</div>
+                      <div className="mt-1 text-xs text-muted-foreground">{o.d}</div>
+                    </button>
+                  ))}
+                </div>
+              </fieldset>
+
+              <fieldset>
+                <legend className="mb-3 text-sm font-semibold">Event family</legend>
+                <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
+                  {(
+                    [
+                      ["dividend", "Dividend"],
+                      ["split", "Split / consolidation"],
+                      ["merger", "M&A"],
+                      ["spinoff", "Spin-off"],
+                      ["rights", "Rights issue"],
+                      ["tender", "Tender / buyback"],
+                      ["return_of_capital", "Return of capital"],
+                      ["delisting", "Delisting"],
+                      ["other", "Other"],
+                    ] as const
+                  ).map(([value, label]) => (
+                    <button
+                      key={value}
+                      type="button"
+                      onClick={() =>
+                        setInput((p) => ({
+                          ...p,
+                          eventFamily: value,
+                        }))
+                      }
+                      className={cn(
+                        "rounded-xl border px-3 py-2.5 text-left text-xs font-medium transition-all hover:border-primary/50 sm:text-sm",
+                        input.eventFamily === value
+                          ? "border-primary bg-primary/10 text-foreground"
+                          : "border-border bg-background/50 text-muted-foreground",
+                      )}
+                    >
+                      {label}
+                    </button>
+                  ))}
+                </div>
+              </fieldset>
+            </div>
+          )}
+
+          {step === 1 && (
+            <div className="space-y-6">
+              {!canShowSubdetails ? (
+                <p className="text-sm text-muted-foreground">
+                  No extra fields are required for this event family in the pilot. You can continue to dates — or pick M&A, spin-off, rights, or dividend for deeper prompts.
+                </p>
+              ) : (
+                <>
+                  {input.eventFamily === "rights" && (
+                    <fieldset>
+                      <legend className="mb-3 text-sm font-semibold">Rights — money-ness</legend>
+                      <div className="grid grid-cols-1 gap-2 sm:grid-cols-3">
+                        {(
+                          [
+                            ["itm", "In-the-money"],
+                            ["otm", "Out-of-the-money"],
+                            ["unknown", "Unknown / unsure"],
+                          ] as const
+                        ).map(([v, label]) => (
+                          <button
+                            key={v}
+                            type="button"
+                            onClick={() => setInput((p) => ({ ...p, rightsItm: v }))}
+                            className={cn(
+                              "rounded-xl border px-3 py-2 text-sm font-medium transition-all",
+                              input.rightsItm === v
+                                ? "border-primary bg-primary/10"
+                                : "border-border bg-background/50",
+                            )}
+                          >
+                            {label}
+                          </button>
+                        ))}
+                      </div>
+                      <label className="mt-4 flex cursor-pointer items-center gap-3 text-sm">
+                        <input
+                          type="checkbox"
+                          checked={input.rightsSubscriptionKnown}
+                          onChange={(e) =>
+                            setInput((p) => ({ ...p, rightsSubscriptionKnown: e.target.checked }))
+                          }
+                          className="size-4 rounded border-border"
+                        />
+                        <span>Subscription price and ratio are known / final</span>
+                      </label>
+                    </fieldset>
+                  )}
+
+                  {input.eventFamily === "merger" && (
+                    <>
+                      <fieldset>
+                        <legend className="mb-3 text-sm font-semibold">M&A — consideration</legend>
+                        <div className="grid grid-cols-1 gap-2 sm:grid-cols-3">
+                          {(
+                            [
+                              ["stock", "Mostly stock"],
+                              ["cash", "Mostly cash"],
+                              ["mixed", "Mixed / unclear"],
+                            ] as const
+                          ).map(([v, label]) => (
+                            <button
+                              key={v}
+                              type="button"
+                              onClick={() => setInput((p) => ({ ...p, mnaDealType: v }))}
+                              className={cn(
+                                "rounded-xl border px-3 py-2 text-sm font-medium transition-all",
+                                input.mnaDealType === v
+                                  ? "border-primary bg-primary/10"
+                                  : "border-border bg-background/50",
+                              )}
+                            >
+                              {label}
+                            </button>
+                          ))}
+                        </div>
+                      </fieldset>
+                      <fieldset>
+                        <legend className="mb-3 text-sm font-semibold">Who is in your managed index?</legend>
+                        <div className="grid grid-cols-1 gap-2 sm:grid-cols-3">
+                          {(
+                            [
+                              ["target_only", "Target only"],
+                              ["acquirer_only", "Acquirer only"],
+                              ["both", "Both in same index"],
+                            ] as const
+                          ).map(([v, label]) => (
+                            <button
+                              key={v}
+                              type="button"
+                              onClick={() => setInput((p) => ({ ...p, mnaIndexParties: v }))}
+                              className={cn(
+                                "rounded-xl border px-3 py-2 text-sm font-medium transition-all",
+                                input.mnaIndexParties === v
+                                  ? "border-primary bg-primary/10"
+                                  : "border-border bg-background/50",
+                              )}
+                            >
+                              {label}
+                            </button>
+                          ))}
+                        </div>
+                      </fieldset>
+                    </>
+                  )}
+
+                  {input.eventFamily === "spinoff" && (
+                    <>
+                      <fieldset>
+                        <legend className="mb-3 text-sm font-semibold">Spin-off child — index eligible?</legend>
+                        <div className="grid grid-cols-1 gap-2 sm:grid-cols-3">
+                          {(
+                            [
+                              ["yes", "Yes — eligible"],
+                              ["no", "No — not eligible"],
+                              ["unknown", "Unknown"],
+                            ] as const
+                          ).map(([v, label]) => (
+                            <button
+                              key={v}
+                              type="button"
+                              onClick={() => setInput((p) => ({ ...p, spinoffChildEligible: v }))}
+                              className={cn(
+                                "rounded-xl border px-3 py-2 text-sm font-medium transition-all",
+                                input.spinoffChildEligible === v
+                                  ? "border-primary bg-primary/10"
+                                  : "border-border bg-background/50",
+                              )}
+                            >
+                              {label}
+                            </button>
+                          ))}
+                        </div>
+                      </fieldset>
+                      {input.spinoffChildEligible !== "no" && (
+                        <fieldset>
+                          <legend className="mb-3 text-sm font-semibold">Trading phase</legend>
+                          <div className="grid grid-cols-1 gap-2 sm:grid-cols-3">
+                            {(
+                              [
+                                ["placeholder", "Placeholder / WI only"],
+                                ["live_trade", "Regular market trading"],
+                                ["unknown", "Unknown"],
+                              ] as const
+                            ).map(([v, label]) => (
+                              <button
+                                key={v}
+                                type="button"
+                                onClick={() => setInput((p) => ({ ...p, spinoffPhase: v }))}
+                                className={cn(
+                                  "rounded-xl border px-3 py-2 text-sm font-medium transition-all",
+                                  input.spinoffPhase === v
+                                    ? "border-primary bg-primary/10"
+                                    : "border-border bg-background/50",
+                                )}
+                              >
+                                {label}
+                              </button>
+                            ))}
+                          </div>
+                        </fieldset>
+                      )}
+                    </>
+                  )}
+
+                  {input.eventFamily === "dividend" && (
+                    <>
+                      <fieldset>
+                        <legend className="mb-3 text-sm font-semibold">Dividend type</legend>
+                        <div className="grid grid-cols-1 gap-2 sm:grid-cols-3">
+                          {(
+                            [
+                              ["ordinary", "Ordinary"],
+                              ["special", "Special"],
+                              ["unknown", "Unknown"],
+                            ] as const
+                          ).map(([v, label]) => (
+                            <button
+                              key={v}
+                              type="button"
+                              onClick={() => setInput((p) => ({ ...p, dividendFlavor: v }))}
+                              className={cn(
+                                "rounded-xl border px-3 py-2 text-sm font-medium transition-all",
+                                input.dividendFlavor === v
+                                  ? "border-primary bg-primary/10"
+                                  : "border-border bg-background/50",
+                              )}
+                            >
+                              {label}
+                            </button>
+                          ))}
+                        </div>
+                      </fieldset>
+                      <fieldset>
+                        <legend className="mb-3 text-sm font-semibold">Index return variant (context)</legend>
+                        <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
+                          {(
+                            [
+                              ["pr", "PR"],
+                              ["tr", "TR"],
+                              ["ntr", "NTR"],
+                              ["unknown", "N/A"],
+                            ] as const
+                          ).map(([v, label]) => (
+                            <button
+                              key={v}
+                              type="button"
+                              onClick={() => setInput((p) => ({ ...p, indexReturnVariant: v }))}
+                              className={cn(
+                                "rounded-xl border px-3 py-2 text-sm font-medium transition-all",
+                                input.indexReturnVariant === v
+                                  ? "border-primary bg-primary/10"
+                                  : "border-border bg-background/50",
+                              )}
+                            >
+                              {label}
+                            </button>
+                          ))}
+                        </div>
+                      </fieldset>
+                    </>
+                  )}
+                </>
+              )}
+            </div>
+          )}
+
+          {step === 2 && (
+            <div className="space-y-4">
+              <div>
+                <label htmlFor="eff-date" className="mb-1.5 block text-sm font-semibold">
+                  Effective date <span className="text-destructive">*</span>
+                </label>
+                <input
+                  id="eff-date"
+                  type="date"
+                  value={input.effectiveDate}
+                  onChange={(e) => setInput((p) => ({ ...p, effectiveDate: e.target.value }))}
+                  className="w-full max-w-xs rounded-xl border border-border bg-background px-3 py-2 text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                  required
+                />
+              </div>
+              <div>
+                <label htmlFor="ex-date" className="mb-1.5 block text-sm font-semibold">
+                  Ex-date <span className="text-muted-foreground font-normal">(optional)</span>
+                </label>
+                <input
+                  id="ex-date"
+                  type="date"
+                  value={input.exDate}
+                  onChange={(e) => setInput((p) => ({ ...p, exDate: e.target.value }))}
+                  className="w-full max-w-xs rounded-xl border border-border bg-background px-3 py-2 text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                />
+              </div>
+              <div>
+                <label htmlFor="asof-date" className="mb-1.5 block text-sm font-semibold">
+                  Projection files as of <span className="text-destructive">*</span>
+                </label>
+                <input
+                  id="asof-date"
+                  type="date"
+                  value={input.dataAsOf}
+                  onChange={(e) => setInput((p) => ({ ...p, dataAsOf: e.target.value }))}
+                  className="w-full max-w-xs rounded-xl border border-border bg-background px-3 py-2 text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                  required
+                />
+                <p className="mt-1 text-xs text-muted-foreground">
+                  Usually “today” for the file drop you are comparing.
+                </p>
+              </div>
+            </div>
+          )}
+
+          {step === 3 && (
+            <div className="space-y-6">
+              <div>
+                <p className="mb-2 text-sm font-semibold">Appears missing (no projection line / empty)</p>
+                <div className="flex flex-wrap gap-2">
+                  {VENDOR_IDS.map((id) => (
+                    <Button
+                      key={`m-${id}`}
+                      type="button"
+                      variant={input.missingVendors.includes(id) ? "default" : "outline"}
+                      size="sm"
+                      onClick={() =>
+                        setInput((p) => ({
+                          ...p,
+                          missingVendors: toggleVendor(p.missingVendors, id),
+                        }))
+                      }
+                    >
+                      {vendorLabel(id)}
+                    </Button>
+                  ))}
+                </div>
+              </div>
+              <div>
+                <p className="mb-2 text-sm font-semibold">Sent projection file as of that date</p>
+                <div className="flex flex-wrap gap-2">
+                  {VENDOR_IDS.map((id) => (
+                    <Button
+                      key={`p-${id}`}
+                      type="button"
+                      variant={input.presentVendors.includes(id) ? "default" : "outline"}
+                      size="sm"
+                      onClick={() =>
+                        setInput((p) => ({
+                          ...p,
+                          presentVendors: toggleVendor(p.presentVendors, id),
+                        }))
+                      }
+                    >
+                      {vendorLabel(id)}
+                    </Button>
+                  ))}
+                </div>
+              </div>
+              <div>
+                <label htmlFor="sim-notes" className="mb-1.5 block text-sm font-semibold">
+                  Notes <span className="text-muted-foreground font-normal">(optional)</span>
+                </label>
+                <textarea
+                  id="sim-notes"
+                  value={input.notes}
+                  onChange={(e) => setInput((p) => ({ ...p, notes: e.target.value.slice(0, 500) }))}
+                  rows={3}
+                  placeholder="Ticker, index name, or other context (shown in summary only)."
+                  className="w-full rounded-xl border border-border bg-background px-3 py-2 text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                />
+                <p className="mt-1 text-xs text-muted-foreground">{input.notes.length}/500</p>
+              </div>
+            </div>
+          )}
+
+          {step === 4 && result && (
+            <div className="space-y-6">
+              <p className="rounded-2xl border border-border bg-background/60 p-4 text-sm leading-relaxed">
+                {result.summary}
+              </p>
+              <ul className="space-y-3">
+                {result.hypotheses.map((h) => (
+                  <li
+                    key={h.id}
+                    className={cn(
+                      "rounded-2xl border p-4",
+                      relevanceStyles(h.relevance),
+                    )}
+                  >
+                    <div className="mb-2 flex flex-wrap items-center gap-2">
+                      <span className="text-sm font-bold">{h.title}</span>
+                      <span className="rounded-full border border-current/30 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide">
+                        {h.relevance}
+                      </span>
+                    </div>
+                    <p className="text-sm leading-relaxed opacity-95">{h.explanation}</p>
+                    {h.appliesToVendors.length > 0 && (
+                      <p className="mt-2 text-xs opacity-80">
+                        Most relevant for missing: {h.appliesToVendors.map(vendorLabel).join(", ")}
+                      </p>
+                    )}
+                  </li>
+                ))}
+              </ul>
+              <div>
+                <p className="mb-2 text-sm font-semibold">Next steps</p>
+                <div className="flex flex-wrap gap-2">
+                  {result.nextStepLinks.map((l) => (
+                    <Button key={l.href} variant="secondary" size="sm" nativeButton={false} render={<Link href={l.href} />}>
+                      {l.label}
+                    </Button>
+                  ))}
+                </div>
+              </div>
+              <p className="text-xs leading-relaxed text-muted-foreground">{result.disclaimer}</p>
+              <p className="text-[10px] text-muted-foreground">Simulator rules v{result.rulesVersion}</p>
+            </div>
+          )}
+        </motion.div>
+      </AnimatePresence>
+
+      {stepError && (
+        <p className="mt-3 text-sm text-destructive" role="alert">
+          {stepError}
+        </p>
+      )}
+
+      <div className="mt-8 flex flex-col-reverse gap-3 border-t border-border pt-6 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex gap-2">
+          {step > 0 && step < 4 && (
+            <Button type="button" variant="outline" size="default" onClick={goBack}>
+              <ArrowLeftIcon data-icon="inline-start" className="size-4" />
+              Back
+            </Button>
+          )}
+          {step === 4 && (
+            <Button type="button" variant="outline" onClick={reset}>
+              Start over
+            </Button>
+          )}
+        </div>
+        <div className="flex gap-2 sm:ml-auto">
+          {step < 4 ? (
+            <Button type="button" onClick={goNext}>
+              {step === 3 ? (
+                <>
+                  Run simulation
+                  <SparklesIcon data-icon="inline-end" className="size-4" />
+                </>
+              ) : (
+                <>
+                  Continue
+                  <ArrowRightIcon data-icon="inline-end" className="size-4" />
+                </>
+              )}
+            </Button>
+          ) : null}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/projection-gap-simulator.tsx
+++ b/src/components/projection-gap-simulator.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { AnimatePresence, motion } from "framer-motion";
 import { ArrowLeftIcon, ArrowRightIcon, CheckIcon } from "lucide-react";
 
+import { surfaceOuterClass } from "@/components/surface-section";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { VENDOR_IDS, vendorLabel, type VendorId } from "@/lib/vendors";
@@ -180,7 +181,10 @@ export function ProjectionGapSimulator() {
   return (
     <section
       id="projection-gap-simulator"
-      className="relative w-full max-w-full min-w-0 overflow-hidden rounded-[2rem] border border-white/10 bg-gradient-to-br from-card/95 via-card/90 to-primary/5 p-5 shadow-2xl shadow-black/25 ring-1 ring-white/5 sm:p-8 md:p-10"
+      className={cn(
+        "relative w-full max-w-full min-w-0 overflow-hidden p-5 shadow-2xl shadow-black/25 sm:p-8 md:p-10",
+        surfaceOuterClass,
+      )}
       aria-labelledby="simulator-heading"
     >
       <div className="pointer-events-none absolute -right-24 -top-24 size-72 rounded-full bg-primary/15 blur-3xl" aria-hidden />
@@ -188,7 +192,7 @@ export function ProjectionGapSimulator() {
 
       <div className="relative flex min-w-0 flex-col gap-8 xl:flex-row xl:gap-8">
         <nav
-          className="w-full shrink-0 xl:w-40 xl:max-w-[11rem]"
+          className="w-full shrink-0 xl:w-40 xl:max-w-[11rem] xl:shrink-0"
           aria-label="Simulator steps"
         >
           <span className="mb-1 block text-[11px] font-medium uppercase tracking-[0.2em] text-muted-foreground xl:sr-only">

--- a/src/components/projection-gap-simulator.tsx
+++ b/src/components/projection-gap-simulator.tsx
@@ -261,7 +261,7 @@ export function ProjectionGapSimulator() {
                     <p className="text-sm leading-relaxed text-muted-foreground">
                       This only filters which event types you can pick next — the simulator still infers mandatory vs voluntary from the event itself.
                     </p>
-                    <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+                    <div className="grid min-w-0 grid-cols-1 gap-3 md:grid-cols-2">
                       <button
                         type="button"
                         onClick={() =>
@@ -323,14 +323,15 @@ export function ProjectionGapSimulator() {
                       Showing types that match <span className="font-medium text-foreground">{input.eventCategory === "mandatory" ? "mandatory" : "voluntary"}</span> flows.
                       {impliedClass === "voluntary" ? " Class: voluntary." : " Class: mandatory."}
                     </p>
-                    <div className="grid grid-cols-1 gap-2 md:grid-cols-2">
+                    {/* min-w-0: grid items default to min-width:auto and refuse to shrink — caused ~93px spill */}
+                    <div className="grid min-w-0 grid-cols-1 gap-2 sm:grid-cols-2">
                       {allowedFamilies.map((value) => (
                         <button
                           key={value}
                           type="button"
                           onClick={() => setInput((p) => ({ ...p, eventFamily: value }))}
                           className={cn(
-                            "rounded-2xl border px-4 py-3.5 text-left text-sm font-medium leading-snug transition-all",
+                            "min-w-0 max-w-full break-words rounded-2xl border px-4 py-3.5 text-left text-sm font-medium leading-snug transition-all",
                             input.eventFamily === value
                               ? "border-primary/45 bg-primary/12 text-foreground"
                               : "border-border/70 bg-background/35 text-muted-foreground hover:border-primary/30 hover:text-foreground",

--- a/src/components/projection-gap-simulator.tsx
+++ b/src/components/projection-gap-simulator.tsx
@@ -27,6 +27,15 @@ const STEP_LABELS = [
   "Results",
 ] as const;
 
+const STEP_LABELS_SHORT = [
+  "Category",
+  "Type",
+  "Context",
+  "Dates",
+  "Vendors",
+  "Results",
+] as const;
+
 function todayIso(): string {
   const d = new Date();
   const y = d.getFullYear();
@@ -177,29 +186,34 @@ export function ProjectionGapSimulator() {
       <div className="pointer-events-none absolute -right-24 -top-24 size-72 rounded-full bg-primary/15 blur-3xl" aria-hidden />
       <div className="pointer-events-none absolute -bottom-32 -left-16 size-64 rounded-full bg-foreground/5 blur-3xl" aria-hidden />
 
-      <div className="relative flex min-w-0 flex-col gap-8 lg:flex-row lg:gap-10">
-        {/* Step rail — full labels, no truncation */}
+      <div className="relative flex min-w-0 flex-col gap-8 xl:flex-row xl:gap-8">
         <nav
-          className="min-w-0 shrink-0 lg:w-52"
+          className="w-full shrink-0 xl:w-40 xl:max-w-[11rem]"
           aria-label="Simulator steps"
         >
-          <p className="mb-1 text-[11px] font-medium uppercase tracking-[0.2em] text-muted-foreground">
+          <span className="mb-1 block text-[11px] font-medium uppercase tracking-[0.2em] text-muted-foreground xl:sr-only">
             Guide
-          </p>
-          <h2 id="simulator-heading" className="mb-6 text-lg font-semibold tracking-tight text-foreground sm:text-xl">
-            Projection gap
+          </span>
+          <h2
+            id="simulator-heading"
+            className="mb-4 text-lg font-semibold tracking-tight text-foreground sm:text-xl xl:mb-3 xl:text-base"
+          >
+            Steps
+            <span className="sr-only"> — projection gap simulator</span>
           </h2>
-          <ol className="flex flex-row gap-1 overflow-x-auto pb-1 lg:flex-col lg:gap-0 lg:overflow-visible lg:pb-0">
+          <ol className="flex flex-row gap-1 overflow-x-auto pb-1 xl:flex-col xl:gap-0.5 xl:overflow-visible xl:pb-0">
             {STEP_LABELS.map((label, i) => {
               const done = i < step || (i === STEP_COUNT - 1 && result !== null);
               const active = i === step;
+              const short = STEP_LABELS_SHORT[i];
               return (
-                <li key={label} className="min-w-0 shrink-0 lg:min-w-0">
+                <li key={label} className="min-w-0 shrink-0">
                   <button
                     type="button"
                     onClick={() => goToStep(i)}
+                    title={label}
                     className={cn(
-                      "flex w-full items-start gap-3 rounded-2xl px-3 py-2.5 text-left transition-colors lg:px-3 lg:py-3",
+                      "flex w-full min-w-0 items-start gap-2 rounded-2xl px-3 py-2.5 text-left transition-colors xl:gap-2 xl:px-2 xl:py-2",
                       active
                         ? "bg-foreground/[0.06] text-foreground"
                         : "text-muted-foreground hover:bg-foreground/[0.04] hover:text-foreground",
@@ -218,13 +232,12 @@ export function ProjectionGapSimulator() {
                     >
                       {done && !active ? <CheckIcon className="size-3.5" /> : i + 1}
                     </span>
-                    <span className="min-w-0 pt-0.5">
-                      <span className="block text-sm font-medium leading-snug whitespace-normal">
-                        {label}
-                      </span>
+                    <span className="min-w-0 flex-1 pt-0.5">
+                      <span className="block text-sm font-medium leading-snug xl:hidden">{label}</span>
+                      <span className="hidden text-xs font-medium leading-snug xl:block">{short}</span>
                       {i === 1 && (
-                        <span className="mt-0.5 block text-xs leading-snug text-muted-foreground whitespace-normal">
-                          {input.eventCategory === "mandatory" ? "Company-driven" : "Shareholder choice"}
+                        <span className="mt-0.5 hidden text-[10px] leading-snug text-muted-foreground xl:block">
+                          {input.eventCategory === "mandatory" ? "Mandatory" : "Voluntary"}
                         </span>
                       )}
                     </span>
@@ -235,15 +248,14 @@ export function ProjectionGapSimulator() {
           </ol>
         </nav>
 
-        {/* Main panel */}
-        <div className="min-w-0 w-full max-w-full flex-1">
+        <div className="min-w-0 w-full max-w-full flex-1 basis-0">
           <div className="mb-6">
             <p className="text-sm leading-relaxed text-muted-foreground">
               A calm walkthrough — tell us what you are seeing. We will suggest plausible reasons, not vendor rulings.
             </p>
           </div>
 
-          <div className="max-h-[min(70vh,640px)] min-h-0 min-w-0 overflow-y-auto overflow-x-auto pr-1 [-webkit-overflow-scrolling:touch]">
+          <div className="max-h-[min(70vh,640px)] min-h-0 min-w-0 overflow-y-auto overflow-x-hidden pr-1 [-webkit-overflow-scrolling:touch]">
             <AnimatePresence mode="wait">
               <motion.div
                 key={step}
@@ -698,12 +710,14 @@ export function ProjectionGapSimulator() {
 
                 {step === 4 && (
                   <div className="space-y-6">
-                    <p className="text-base font-medium text-foreground">Vendor picture</p>
-                    {/* One column until xl so narrow hero columns do not split ~94px tracks; min-w-0 fixes grid/flex overflow */}
-                    <div className="grid min-w-0 grid-cols-1 gap-6 xl:grid-cols-2">
+                    <p className="text-base font-medium text-foreground">Vendors</p>
+                    <div className="grid min-w-0 grid-cols-1 gap-6 2xl:grid-cols-2">
                       <div className="min-w-0 overflow-hidden rounded-2xl border border-border/70 bg-background/30 p-4 sm:p-5">
-                        <p className="mb-3 text-pretty text-sm font-medium leading-snug text-foreground">
-                          Missing or empty in the feed
+                        <p
+                          className="mb-3 text-sm font-medium leading-tight text-foreground"
+                          title="Vendors missing from your projection feed or showing an empty line"
+                        >
+                          Missing in feed
                         </p>
                         <div className="flex min-w-0 flex-wrap gap-2">
                           {VENDOR_IDS.map((id) => (
@@ -717,7 +731,7 @@ export function ProjectionGapSimulator() {
                                 }))
                               }
                               className={cn(
-                                "inline-flex min-h-9 min-w-0 max-w-full shrink break-words rounded-2xl border px-3 py-2 text-center text-xs font-medium leading-snug transition-all sm:text-sm",
+                                "inline-flex min-h-9 shrink-0 whitespace-nowrap rounded-full border px-3 py-2 text-left text-xs font-medium transition-all sm:text-sm",
                                 input.missingVendors.includes(id)
                                   ? "border-primary/50 bg-primary/20 text-foreground"
                                   : "border-border/80 bg-background/60 text-muted-foreground hover:border-primary/30",
@@ -729,8 +743,11 @@ export function ProjectionGapSimulator() {
                         </div>
                       </div>
                       <div className="min-w-0 overflow-hidden rounded-2xl border border-border/70 bg-background/30 p-4 sm:p-5">
-                        <p className="mb-3 text-pretty text-sm font-medium leading-snug text-foreground">
-                          Already in the projection file
+                        <p
+                          className="mb-3 text-sm font-medium leading-tight text-foreground"
+                          title="Vendors that already published this event in the projection file"
+                        >
+                          In the file
                         </p>
                         <div className="flex min-w-0 flex-wrap gap-2">
                           {VENDOR_IDS.map((id) => (
@@ -744,7 +761,7 @@ export function ProjectionGapSimulator() {
                                 }))
                               }
                               className={cn(
-                                "inline-flex min-h-9 min-w-0 max-w-full shrink break-words rounded-2xl border px-3 py-2 text-center text-xs font-medium leading-snug transition-all sm:text-sm",
+                                "inline-flex min-h-9 shrink-0 whitespace-nowrap rounded-full border px-3 py-2 text-left text-xs font-medium transition-all sm:text-sm",
                                 input.presentVendors.includes(id)
                                   ? "border-primary/50 bg-primary/20 text-foreground"
                                   : "border-border/80 bg-background/60 text-muted-foreground hover:border-primary/30",

--- a/src/components/surface-section.tsx
+++ b/src/components/surface-section.tsx
@@ -1,0 +1,48 @@
+import type { ReactNode } from "react";
+
+import { cn } from "@/lib/utils";
+
+/** Shared outer shell: large radius, soft gradient, hairline ring (simulator aesthetic). */
+export const surfaceOuterClass =
+  "rounded-[2rem] border border-white/10 bg-gradient-to-br from-card/95 via-card/90 to-primary/5 ring-1 ring-white/5";
+
+const paddingClasses = {
+  comfortable: "p-6 sm:p-8 md:p-10",
+  compact: "p-6 sm:p-8",
+  tight: "p-5 sm:p-8",
+} as const;
+
+const shadowClasses = {
+  section: "shadow-xl",
+  elevated: "shadow-2xl shadow-black/25",
+} as const;
+
+export type SurfaceSectionPadding = keyof typeof paddingClasses;
+export type SurfaceSectionShadow = keyof typeof shadowClasses;
+
+type SurfaceSectionProps = {
+  children: ReactNode;
+  className?: string;
+  padding?: SurfaceSectionPadding;
+  shadow?: SurfaceSectionShadow;
+};
+
+export function SurfaceSection({
+  children,
+  className,
+  padding = "compact",
+  shadow = "section",
+}: SurfaceSectionProps) {
+  return (
+    <div
+      className={cn(
+        surfaceOuterClass,
+        paddingClasses[padding],
+        shadowClasses[shadow],
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/lib/simulator/simulator-engine.ts
+++ b/src/lib/simulator/simulator-engine.ts
@@ -1,0 +1,350 @@
+import type { VendorId } from "@/lib/vendors";
+import { vendorLabel } from "@/lib/vendors";
+import type {
+  EventFamily,
+  Hypothesis,
+  Relevance,
+  SimulatorInput,
+  SimulatorResult,
+} from "@/lib/simulator/types";
+
+const RULES_VERSION = "1.0.0";
+
+const DISCLAIMER =
+  "This simulator produces possible explanations only. It does not replace official vendor methodology, notices, or your internal policy. Always confirm with vendor documentation and primary sources.";
+
+function formatIsoDate(iso: string): string {
+  if (!iso) return "—";
+  const d = new Date(iso + "T12:00:00");
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+/**
+ * Business days strictly after `fromIso` through `toIso` inclusive (Mon–Fri only; ignores holidays).
+ * Wed → next Wed = 5.
+ */
+function businessDaysAfterThrough(fromIso: string, toIso: string): number | null {
+  if (!fromIso || !toIso) return null;
+  const from = new Date(fromIso + "T12:00:00");
+  const to = new Date(toIso + "T12:00:00");
+  if (Number.isNaN(from.getTime()) || Number.isNaN(to.getTime())) return null;
+  if (to.getTime() < from.getTime()) return 0;
+  let cur = new Date(from.getTime());
+  let count = 0;
+  while (true) {
+    cur.setDate(cur.getDate() + 1);
+    if (cur.getTime() > to.getTime()) break;
+    const dow = cur.getDay();
+    if (dow !== 0 && dow !== 6) count++;
+  }
+  return count;
+}
+
+function relScore(r: Relevance): number {
+  if (r === "high") return 3;
+  if (r === "medium") return 2;
+  return 1;
+}
+
+function uniqueVendors(ids: VendorId[]): VendorId[] {
+  return Array.from(new Set(ids));
+}
+
+function listVendors(ids: VendorId[]): string {
+  return uniqueVendors(ids).map(vendorLabel).join(", ");
+}
+
+function overlap(a: VendorId[], b: VendorId[]): VendorId[] {
+  const setB = new Set(b);
+  return a.filter((x) => setB.has(x));
+}
+
+function onlyMissingPresent(
+  missing: VendorId[],
+  present: VendorId[],
+): { onlyMissing: VendorId[]; onlyPresent: VendorId[] } {
+  const m = new Set(missing);
+  const p = new Set(present);
+  const onlyMissing = missing.filter((id) => !p.has(id));
+  const onlyPresent = present.filter((id) => !m.has(id));
+  return { onlyMissing, onlyPresent };
+}
+
+function buildSummary(input: SimulatorInput): string {
+  const eventLabel = `${input.eventClass === "mandatory" ? "Mandatory" : "Voluntary"} / ${humanFamily(input.eventFamily)}`;
+  const eff = formatIsoDate(input.effectiveDate);
+  const asOf = formatIsoDate(input.dataAsOf);
+  const miss = listVendors(input.missingVendors);
+  const pres = listVendors(input.presentVendors);
+  const note = input.notes.trim()
+    ? ` Context: ${input.notes.trim().slice(0, 200)}${input.notes.trim().length > 200 ? "…" : ""}`
+    : "";
+  return `You described a ${eventLabel} with effective date ${eff}. Projection files as of ${asOf} appear missing for: ${miss || "—"}. Present from: ${pres || "—"}.${note}`;
+}
+
+function humanFamily(f: EventFamily): string {
+  const map: Record<EventFamily, string> = {
+    dividend: "Dividend",
+    split: "Stock split / consolidation",
+    merger: "M&A",
+    spinoff: "Spin-off",
+    rights: "Rights issue",
+    tender: "Tender / buyback",
+    return_of_capital: "Return of capital",
+    delisting: "Delisting",
+    other: "Other corporate action",
+  };
+  return map[f];
+}
+
+export function runSimulator(input: SimulatorInput): SimulatorResult {
+  const hypotheses: Hypothesis[] = [];
+  const { onlyMissing, onlyPresent } = onlyMissingPresent(
+    input.missingVendors,
+    input.presentVendors,
+  );
+
+  const dup = overlap(input.missingVendors, input.presentVendors);
+  if (dup.length > 0) {
+    hypotheses.push({
+      id: "input-overlap",
+      title: "Overlapping vendor selection",
+      explanation: `The same vendor cannot be both "missing" and "sent projection" for this exercise: ${listVendors(dup)}. Adjust the selections so each vendor is in at most one list; other hypotheses below assume non-overlapping lists.`,
+      relevance: "high",
+      appliesToVendors: dup,
+    });
+  }
+
+  if (onlyMissing.length === 0 && onlyPresent.length === 0) {
+    hypotheses.push({
+      id: "no-gap",
+      title: "No vendor gap selected",
+      explanation:
+        "Select at least one vendor that appears missing and one that sent a projection file so the simulator can contrast behaviour. If everyone is aligned, divergence may be timing-only or already resolved.",
+      relevance: "medium",
+      appliesToVendors: [],
+    });
+  }
+
+  const bdDataToEffective = businessDaysAfterThrough(input.dataAsOf, input.effectiveDate);
+  if (bdDataToEffective !== null && bdDataToEffective > 5) {
+    hypotheses.push({
+      id: "t5-window",
+      title: "T-5 style coverage window",
+      explanation: `Your "as of" data date (${formatIsoDate(input.dataAsOf)}) is more than five business days before the effective date (${formatIsoDate(input.effectiveDate)}). Vendors commonly publish open-constituent projections for events that fall within a forward coverage window from the data date. Events far outside that window may not appear in projection feeds yet for some vendors, even if others publish earlier placeholders or notices.`,
+      relevance: "high",
+      appliesToVendors: onlyMissing,
+    });
+  }
+
+  if (input.exDate && input.dataAsOf) {
+    const bdToEx = businessDaysAfterThrough(input.dataAsOf, input.exDate);
+    if (bdToEx !== null && bdToEx > 5) {
+      hypotheses.push({
+        id: "ex-before-coverage",
+        title: "Ex-date vs projection snapshot",
+        explanation: `Ex-date is ${formatIsoDate(input.exDate)} relative to data as of ${formatIsoDate(input.dataAsOf)}. Some vendors emphasise ex-date adjustments and grace-period logic; others may delay spin-off child lines until first trade. A large gap between snapshot and ex-date can produce "missing now, appears later" patterns.`,
+        relevance: "medium",
+        appliesToVendors: onlyMissing,
+      });
+    }
+  }
+
+  if (input.eventClass === "voluntary") {
+    hypotheses.push({
+      id: "voluntary-uncertainty",
+      title: "Voluntary event — participation unknown",
+      explanation:
+        "Rights issues, tenders, and similar voluntary actions often require confirmed subscription or acceptance levels before all vendors adjust floats or share counts. It is common for one vendor to reflect partial information (or an early line) while another waits for final results — especially where free-float or materiality thresholds differ.",
+      relevance: "high",
+      appliesToVendors: onlyMissing,
+    });
+  }
+
+  if (input.eventFamily === "merger") {
+    if (input.mnaIndexParties === "both") {
+      hypotheses.push({
+        id: "mna-both-deletion-triggers",
+        title: "Target deletion triggers differ when both names are in the index",
+        explanation:
+          "When target and acquirer are both index constituents, deletion and float rules diverge materially across vendors (e.g. different combinations of acceptance % and free-float conditions). The same deal can therefore show different effective removal dates or interim placeholder treatment in projections.",
+        relevance: "high",
+        appliesToVendors: onlyMissing,
+      });
+    }
+    if (input.mnaIndexParties === "acquirer_only") {
+      hypotheses.push({
+        id: "mna-acquirer-only",
+        title: "Acquirer-only index — adjustment type varies by deal consideration",
+        explanation:
+          "If only the acquirer is in the index, vendors still disagree on how and when to reflect share count and float changes for stock vs cash consideration, and on confirmation gates. One feed may show an early divisor-related adjustment while another waits for settlement or exchange confirmation.",
+        relevance: "medium",
+        appliesToVendors: onlyMissing,
+      });
+    }
+    if (input.mnaDealType === "cash") {
+      hypotheses.push({
+        id: "mna-cash",
+        title: "Cash deal — different adjustment mechanics vs stock",
+        explanation:
+          "Cash mergers are often treated differently from stock mergers for divisor and continuity. A vendor that already published a projection line may be using a different confirmation or price basis than one that is still silent.",
+        relevance: "medium",
+        appliesToVendors: onlyMissing,
+      });
+    }
+  }
+
+  if (input.eventFamily === "spinoff") {
+    if (input.spinoffChildEligible === "no") {
+      hypotheses.push({
+        id: "spinoff-ineligible",
+        title: "Ineligible spin-off child — not all vendors will add a line",
+        explanation:
+          "If the distributed security is not index-eligible (sector, liquidity, domicile), many methodologies never add a child line in projections. Missing vendors may simply not publish a placeholder for a security outside index rules.",
+        relevance: "high",
+        appliesToVendors: onlyMissing,
+      });
+    } else if (input.spinoffChildEligible === "yes") {
+      hypotheses.push({
+        id: "spinoff-placeholder-vs-trade",
+        title: "Placeholder vs first-trade price",
+        explanation:
+          "For an eligible spin-off child, vendors disagree on zero vs estimated vs when-issued pricing, and on how long to wait for real trading. Vendors that use immediate placeholders often appear in feeds earlier than those that require a live market price.",
+        relevance: "high",
+        appliesToVendors: onlyMissing,
+      });
+      if (input.spinoffPhase === "placeholder") {
+        hypotheses.push({
+          id: "spinoff-phase-placeholder",
+          title: "You are still in the placeholder phase",
+          explanation:
+            "If the child has not yet traded regularly, vendors that require a market price may omit the line from projections until first trade, while others already show a floor or estimated price.",
+          relevance: "high",
+          appliesToVendors: onlyMissing,
+        });
+      }
+    }
+  }
+
+  if (input.eventFamily === "rights") {
+    if (input.rightsItm === "otm") {
+      hypotheses.push({
+        id: "rights-otm",
+        title: "Out-of-the-money rights — many vendors ignore",
+        explanation:
+          "OTM rights are often economically irrelevant for index replication; several methodologies do not adjust until or unless terms change or the issue becomes in-the-money. A vendor showing nothing may be consistent with that policy.",
+        relevance: "high",
+        appliesToVendors: onlyMissing,
+      });
+    } else if (input.rightsItm === "itm") {
+      hypotheses.push({
+        id: "rights-itm",
+        title: "In-the-money rights — timing and float still diverge",
+        explanation:
+          "ITM rights usually require attention, but vendors still differ on nil-paid lines, subscription results, and free-float effects from non-participation. One vendor may publish a provisional line while another waits for final take-up.",
+        relevance: "medium",
+        appliesToVendors: onlyMissing,
+      });
+    }
+    if (!input.rightsSubscriptionKnown) {
+      hypotheses.push({
+        id: "rights-unknown-terms",
+        title: "Incomplete terms — vendor gating",
+        explanation:
+          "If subscription price or ratio is not yet final, some vendors suppress projection updates until terms are confirmed, while others publish provisional lines subject to revision.",
+        relevance: "medium",
+        appliesToVendors: onlyMissing,
+      });
+    }
+  }
+
+  if (input.eventFamily === "dividend") {
+    if (input.dividendFlavor === "special") {
+      hypotheses.push({
+        id: "div-special",
+        title: "Special dividend — different treatment vs ordinary",
+        explanation:
+          "Special dividends can be classified and adjusted differently across vendors (price return vs total return series, timing vs ex-date, and materiality). A vendor missing the line may be applying a different event classification or waiting for confirmed gross/net amounts.",
+        relevance: "medium",
+        appliesToVendors: onlyMissing,
+      });
+    }
+    if (input.indexReturnVariant !== "unknown") {
+      hypotheses.push({
+        id: "div-pr-tr-ntr",
+        title: "PR vs TR vs NTR series",
+        explanation:
+          "Dividend impact is most visible on total-return variants. If you are comparing price-return screens to TR/NTR feeds, apparent mismatches can be series selection rather than missing corporate action data.",
+        relevance: "low",
+        appliesToVendors: onlyMissing,
+      });
+    }
+  }
+
+  if (input.eventFamily === "other" || input.eventFamily === "delisting" || input.eventFamily === "tender") {
+    hypotheses.push({
+      id: "generic-methodology",
+      title: "Methodology or feed lag",
+      explanation:
+        "For less common or boundary cases, divergence often comes down to confirmation gates, exchange notices, or feed publication lag rather than disagreement on the economic event. Compare vendor timing tables and check whether the missing feed has published any notice without yet updating open constituents.",
+      relevance: "low",
+      appliesToVendors: onlyMissing,
+    });
+  }
+
+  if (input.eventFamily === "split") {
+    hypotheses.push({
+      id: "split-timing",
+      title: "Split ratio confirmation",
+      explanation:
+        "Stock splits are usually straightforward once confirmed, but vendors can still differ on the snapshot date used for divisor adjustment vs when the split first appears in projection files.",
+      relevance: "low",
+      appliesToVendors: onlyMissing,
+    });
+  }
+
+  const pilotFamilies: EventFamily[] = [
+    "dividend",
+    "split",
+    "merger",
+    "spinoff",
+    "rights",
+  ];
+  if (!pilotFamilies.includes(input.eventFamily)) {
+    hypotheses.push({
+      id: "pilot-stub",
+      title: "Deeper rules coming in a later release",
+      explanation:
+        "Pilot coverage in this version focuses on dividends, splits, M&A, spin-offs, and rights. For this event family, use the Vendor reference for thresholds and timing, and treat simulator output as high-level only.",
+      relevance: "low",
+      appliesToVendors: onlyMissing,
+    });
+  }
+
+  const dedup = new Map<string, Hypothesis>();
+  for (const h of hypotheses) {
+    if (!dedup.has(h.id)) dedup.set(h.id, h);
+  }
+  const sorted = Array.from(dedup.values()).sort(
+    (a, b) => relScore(b.relevance) - relScore(a.relevance),
+  );
+
+  const nextStepLinks = [
+    { label: "Vendor thresholds & timing", href: "/vendors/" },
+    { label: "ISO taxonomy cross-reference", href: "/vendors/iso-taxonomy/" },
+    { label: "Event extraction notes", href: "/vendors/event-extraction/" },
+  ];
+
+  return {
+    summary: buildSummary(input),
+    hypotheses: sorted.slice(0, 8),
+    nextStepLinks,
+    disclaimer: DISCLAIMER,
+    rulesVersion: RULES_VERSION,
+  };
+}

--- a/src/lib/simulator/simulator-engine.ts
+++ b/src/lib/simulator/simulator-engine.ts
@@ -34,7 +34,7 @@ function businessDaysAfterThrough(fromIso: string, toIso: string): number | null
   const to = new Date(toIso + "T12:00:00");
   if (Number.isNaN(from.getTime()) || Number.isNaN(to.getTime())) return null;
   if (to.getTime() < from.getTime()) return 0;
-  let cur = new Date(from.getTime());
+  const cur = new Date(from.getTime());
   let count = 0;
   while (true) {
     cur.setDate(cur.getDate() + 1);

--- a/src/lib/simulator/simulator-engine.ts
+++ b/src/lib/simulator/simulator-engine.ts
@@ -1,5 +1,6 @@
 import type { VendorId } from "@/lib/vendors";
 import { vendorLabel } from "@/lib/vendors";
+import { getEventClassFromFamily, humanFamily } from "@/lib/simulator/taxonomy";
 import type {
   EventFamily,
   Hypothesis,
@@ -8,7 +9,7 @@ import type {
   SimulatorResult,
 } from "@/lib/simulator/types";
 
-const RULES_VERSION = "1.0.0";
+const RULES_VERSION = "1.1.0";
 
 const DISCLAIMER =
   "This simulator produces possible explanations only. It does not replace official vendor methodology, notices, or your internal policy. Always confirm with vendor documentation and primary sources.";
@@ -26,7 +27,6 @@ function formatIsoDate(iso: string): string {
 
 /**
  * Business days strictly after `fromIso` through `toIso` inclusive (Mon–Fri only; ignores holidays).
- * Wed → next Wed = 5.
  */
 function businessDaysAfterThrough(fromIso: string, toIso: string): number | null {
   if (!fromIso || !toIso) return null;
@@ -75,8 +75,17 @@ function onlyMissingPresent(
   return { onlyMissing, onlyPresent };
 }
 
+function parseOptionalPct(raw: string): number | null {
+  const t = raw.trim().replace(/%/g, "");
+  if (t === "") return null;
+  const n = Number.parseFloat(t);
+  if (!Number.isFinite(n)) return null;
+  return n;
+}
+
 function buildSummary(input: SimulatorInput): string {
-  const eventLabel = `${input.eventClass === "mandatory" ? "Mandatory" : "Voluntary"} / ${humanFamily(input.eventFamily)}`;
+  const cls = getEventClassFromFamily(input.eventFamily);
+  const eventLabel = `${cls === "mandatory" ? "Mandatory" : "Voluntary"} — ${humanFamily(input.eventFamily)}`;
   const eff = formatIsoDate(input.effectiveDate);
   const asOf = formatIsoDate(input.dataAsOf);
   const miss = listVendors(input.missingVendors);
@@ -87,27 +96,17 @@ function buildSummary(input: SimulatorInput): string {
   return `You described a ${eventLabel} with effective date ${eff}. Projection files as of ${asOf} appear missing for: ${miss || "—"}. Present from: ${pres || "—"}.${note}`;
 }
 
-function humanFamily(f: EventFamily): string {
-  const map: Record<EventFamily, string> = {
-    dividend: "Dividend",
-    split: "Stock split / consolidation",
-    merger: "M&A",
-    spinoff: "Spin-off",
-    rights: "Rights issue",
-    tender: "Tender / buyback",
-    return_of_capital: "Return of capital",
-    delisting: "Delisting",
-    other: "Other corporate action",
-  };
-  return map[f];
-}
-
 export function runSimulator(input: SimulatorInput): SimulatorResult {
   const hypotheses: Hypothesis[] = [];
   const { onlyMissing, onlyPresent } = onlyMissingPresent(
     input.missingVendors,
     input.presentVendors,
   );
+  const eventClass = getEventClassFromFamily(input.eventFamily);
+  const divYield = parseOptionalPct(input.metrics.dividendYieldPct);
+  const ffDelta = parseOptionalPct(input.metrics.freeFloatChangePp);
+  const tenderPct = parseOptionalPct(input.metrics.tenderAcceptancePct);
+  const rightsDisc = parseOptionalPct(input.metrics.rightsDiscountPct);
 
   const dup = overlap(input.missingVendors, input.presentVendors);
   if (dup.length > 0) {
@@ -135,8 +134,8 @@ export function runSimulator(input: SimulatorInput): SimulatorResult {
   if (bdDataToEffective !== null && bdDataToEffective > 5) {
     hypotheses.push({
       id: "t5-window",
-      title: "T-5 style coverage window",
-      explanation: `Your "as of" data date (${formatIsoDate(input.dataAsOf)}) is more than five business days before the effective date (${formatIsoDate(input.effectiveDate)}). Vendors commonly publish open-constituent projections for events that fall within a forward coverage window from the data date. Events far outside that window may not appear in projection feeds yet for some vendors, even if others publish earlier placeholders or notices.`,
+      title: "Coverage window vs effective date",
+      explanation: `Your "as of" data date (${formatIsoDate(input.dataAsOf)}) is more than five business days before the effective date (${formatIsoDate(input.effectiveDate)}). Vendors often publish open-constituent projections for events within a forward window from the data date. Events far outside that window may not appear in some feeds yet, even if others publish earlier placeholders or notices.`,
       relevance: "high",
       appliesToVendors: onlyMissing,
     });
@@ -155,13 +154,73 @@ export function runSimulator(input: SimulatorInput): SimulatorResult {
     }
   }
 
-  if (input.eventClass === "voluntary") {
+  if (eventClass === "voluntary") {
     hypotheses.push({
       id: "voluntary-uncertainty",
-      title: "Voluntary event — participation unknown",
+      title: "Voluntary event — participation may still be open",
       explanation:
-        "Rights issues, tenders, and similar voluntary actions often require confirmed subscription or acceptance levels before all vendors adjust floats or share counts. It is common for one vendor to reflect partial information (or an early line) while another waits for final results — especially where free-float or materiality thresholds differ.",
+        "Rights issues, tenders, and similar voluntary actions often need confirmed subscription or acceptance before every vendor adjusts floats or share counts. One feed may show an early or provisional line while another waits for final results — especially where free-float or materiality thresholds differ.",
       relevance: "high",
+      appliesToVendors: onlyMissing,
+    });
+  }
+
+  if (input.eventFamily === "dividend" && divYield !== null) {
+    if (input.dividendFlavor === "special" && divYield >= 5) {
+      hypotheses.push({
+        id: "div-yield-special-large",
+        title: "Large special dividend relative to price",
+        explanation: `You indicated a dividend yield of about ${divYield}% of price. A large special distribution can change how vendors classify the event (e.g. return of capital vs dividend) and whether it is deferred or treated across PR vs TR series. Some feeds wait for confirmed gross or net amounts before publishing a projection line.`,
+        relevance: "high",
+        appliesToVendors: onlyMissing,
+      });
+    } else if (divYield >= 3 && input.dividendFlavor !== "ordinary") {
+      hypotheses.push({
+        id: "div-yield-material",
+        title: "Materiality relative to price",
+        explanation: `A dividend of roughly ${divYield}% of price may cross materiality thresholds for some vendors but not others, or may be handled differently on PR vs TR. Below-threshold amounts can be deferred to the next review cycle on some indices.`,
+        relevance: "medium",
+        appliesToVendors: onlyMissing,
+      });
+    }
+  }
+
+  if (ffDelta !== null && Math.abs(ffDelta) >= 5) {
+    hypotheses.push({
+      id: "float-delta",
+      title: "Meaningful free-float change",
+      explanation: `You entered about ${ffDelta >= 0 ? "+" : ""}${ffDelta} percentage points of free-float change. Several vendors apply extraordinary float adjustments or different timing when float moves by roughly five points or more. That alone can explain why one feed already reflects a line and another does not.`,
+      relevance: "high",
+      appliesToVendors: onlyMissing,
+    });
+  }
+
+  if (input.eventFamily === "tender" && tenderPct !== null) {
+    if (tenderPct < 50) {
+      hypotheses.push({
+        id: "tender-low",
+        title: "Low acceptance so far",
+        explanation: `With acceptance around ${tenderPct}%, some methodologies will not treat the offer as sufficiently progressed to adjust or delete lines, while others may publish provisional scenarios. Divergence often appears around the acceptance thresholds each vendor publishes.`,
+        relevance: "medium",
+        appliesToVendors: onlyMissing,
+      });
+    } else if (tenderPct >= 85) {
+      hypotheses.push({
+        id: "tender-high",
+        title: "High acceptance — deletion timing may still differ",
+        explanation: `Around ${tenderPct}% acceptance often crosses key thresholds, but vendors still disagree on when a target line is removed or when float is updated — especially if conditions combine acceptance % with free-float tests.`,
+        relevance: "medium",
+        appliesToVendors: onlyMissing,
+      });
+    }
+  }
+
+  if (input.eventFamily === "rights" && rightsDisc !== null && rightsDisc > 0) {
+    hypotheses.push({
+      id: "rights-discount",
+      title: "Rights trading below intrinsic",
+      explanation: `You noted the rights trade roughly ${rightsDisc}% below theoretical value. Deep discounts can correlate with low exercise expectations; some vendors delay or omit adjustments until the outcome is clearer, while others publish nil-paid lines earlier.`,
+      relevance: "low",
       appliesToVendors: onlyMissing,
     });
   }
@@ -180,7 +239,7 @@ export function runSimulator(input: SimulatorInput): SimulatorResult {
     if (input.mnaIndexParties === "acquirer_only") {
       hypotheses.push({
         id: "mna-acquirer-only",
-        title: "Acquirer-only index — adjustment type varies by deal consideration",
+        title: "Acquirer-only index — consideration still drives timing",
         explanation:
           "If only the acquirer is in the index, vendors still disagree on how and when to reflect share count and float changes for stock vs cash consideration, and on confirmation gates. One feed may show an early divisor-related adjustment while another waits for settlement or exchange confirmation.",
         relevance: "medium",
@@ -221,7 +280,7 @@ export function runSimulator(input: SimulatorInput): SimulatorResult {
       if (input.spinoffPhase === "placeholder") {
         hypotheses.push({
           id: "spinoff-phase-placeholder",
-          title: "You are still in the placeholder phase",
+          title: "Still in the placeholder phase",
           explanation:
             "If the child has not yet traded regularly, vendors that require a market price may omit the line from projections until first trade, while others already show a floor or estimated price.",
           relevance: "high",
@@ -269,7 +328,7 @@ export function runSimulator(input: SimulatorInput): SimulatorResult {
         id: "div-special",
         title: "Special dividend — different treatment vs ordinary",
         explanation:
-          "Special dividends can be classified and adjusted differently across vendors (price return vs total return series, timing vs ex-date, and materiality). A vendor missing the line may be applying a different event classification or waiting for confirmed gross/net amounts.",
+          "Special dividends can be classified and adjusted differently across vendors (price return vs total return series, timing vs ex-date, and materiality). A vendor missing the line may be applying a different event classification or waiting for confirmed gross or net amounts.",
         relevance: "medium",
         appliesToVendors: onlyMissing,
       });
@@ -279,7 +338,7 @@ export function runSimulator(input: SimulatorInput): SimulatorResult {
         id: "div-pr-tr-ntr",
         title: "PR vs TR vs NTR series",
         explanation:
-          "Dividend impact is most visible on total-return variants. If you are comparing price-return screens to TR/NTR feeds, apparent mismatches can be series selection rather than missing corporate action data.",
+          "Dividend impact is most visible on total-return variants. If you are comparing price-return screens to TR or NTR feeds, apparent mismatches can be series selection rather than missing corporate action data.",
         relevance: "low",
         appliesToVendors: onlyMissing,
       });
@@ -318,9 +377,9 @@ export function runSimulator(input: SimulatorInput): SimulatorResult {
   if (!pilotFamilies.includes(input.eventFamily)) {
     hypotheses.push({
       id: "pilot-stub",
-      title: "Deeper rules coming in a later release",
+      title: "Broader reference may be needed",
       explanation:
-        "Pilot coverage in this version focuses on dividends, splits, M&A, spin-offs, and rights. For this event family, use the Vendor reference for thresholds and timing, and treat simulator output as high-level only.",
+        "The richest rule set here focuses on dividends, splits, M&A, spin-offs, and rights. For this event type, lean on the vendor reference for thresholds and timing, and treat simulator output as a starting point.",
       relevance: "low",
       appliesToVendors: onlyMissing,
     });
@@ -335,8 +394,8 @@ export function runSimulator(input: SimulatorInput): SimulatorResult {
   );
 
   const nextStepLinks = [
-    { label: "Vendor thresholds & timing", href: "/vendors/" },
-    { label: "ISO taxonomy cross-reference", href: "/vendors/iso-taxonomy/" },
+    { label: "Vendor thresholds and timing", href: "/vendors/" },
+    { label: "ISO taxonomy", href: "/vendors/iso-taxonomy/" },
     { label: "Event extraction notes", href: "/vendors/event-extraction/" },
   ];
 

--- a/src/lib/simulator/taxonomy.ts
+++ b/src/lib/simulator/taxonomy.ts
@@ -1,0 +1,49 @@
+import type { EventClass, EventFamily } from "@/lib/simulator/types";
+
+/** Event class is determined by the selected family — no separate user step. */
+export const FAMILY_TO_CLASS: Record<EventFamily, EventClass> = {
+  dividend: "mandatory",
+  split: "mandatory",
+  merger: "mandatory",
+  spinoff: "mandatory",
+  return_of_capital: "mandatory",
+  delisting: "mandatory",
+  rights: "voluntary",
+  tender: "voluntary",
+  other: "mandatory",
+};
+
+export const MANDATORY_FAMILIES: EventFamily[] = [
+  "dividend",
+  "split",
+  "merger",
+  "spinoff",
+  "return_of_capital",
+  "delisting",
+  "other",
+];
+
+export const VOLUNTARY_FAMILIES: EventFamily[] = ["rights", "tender"];
+
+export function getEventClassFromFamily(family: EventFamily): EventClass {
+  return FAMILY_TO_CLASS[family] ?? "mandatory";
+}
+
+export function familiesForClass(eventClass: EventClass): EventFamily[] {
+  return eventClass === "voluntary" ? [...VOLUNTARY_FAMILIES] : [...MANDATORY_FAMILIES];
+}
+
+export function humanFamily(f: EventFamily): string {
+  const map: Record<EventFamily, string> = {
+    dividend: "Dividend",
+    split: "Stock split or consolidation",
+    merger: "M&A",
+    spinoff: "Spin-off",
+    rights: "Rights issue",
+    tender: "Tender or buyback",
+    return_of_capital: "Return of capital",
+    delisting: "Delisting",
+    other: "Other corporate action",
+  };
+  return map[f];
+}

--- a/src/lib/simulator/types.ts
+++ b/src/lib/simulator/types.ts
@@ -30,8 +30,17 @@ export type IndexReturnVariant = "pr" | "tr" | "ntr" | "unknown";
 
 export type Relevance = "high" | "medium" | "low";
 
+/** Optional numeric hints — empty string in UI means “not provided”. */
+export type SimulatorMetrics = {
+  dividendYieldPct: string;
+  freeFloatChangePp: string;
+  tenderAcceptancePct: string;
+  rightsDiscountPct: string;
+};
+
 export type SimulatorInput = {
-  eventClass: EventClass;
+  /** High-level filter for which event types appear — class is implied by `eventFamily`. */
+  eventCategory: EventClass;
   eventFamily: EventFamily;
   /** Sub-fields — only relevant subsets used per family */
   rightsItm: RightsItm;
@@ -42,6 +51,7 @@ export type SimulatorInput = {
   spinoffPhase: SpinoffPhase;
   dividendFlavor: DividendFlavor;
   indexReturnVariant: IndexReturnVariant;
+  metrics: SimulatorMetrics;
   effectiveDate: string; // YYYY-MM-DD
   exDate: string;
   dataAsOf: string; // YYYY-MM-DD

--- a/src/lib/simulator/types.ts
+++ b/src/lib/simulator/types.ts
@@ -1,0 +1,67 @@
+import type { VendorId } from "@/lib/vendors";
+
+export type EventClass = "mandatory" | "voluntary";
+
+export type EventFamily =
+  | "dividend"
+  | "split"
+  | "merger"
+  | "spinoff"
+  | "rights"
+  | "tender"
+  | "return_of_capital"
+  | "delisting"
+  | "other";
+
+/** Rights issue sub-options */
+export type RightsItm = "itm" | "otm" | "unknown";
+
+/** M&A sub-options */
+export type MnaDealType = "stock" | "cash" | "mixed";
+export type MnaIndexParties = "target_only" | "acquirer_only" | "both";
+
+/** Spin-off sub-options */
+export type SpinoffChildEligible = "yes" | "no" | "unknown";
+export type SpinoffPhase = "placeholder" | "live_trade" | "unknown";
+
+/** Dividend sub-options */
+export type DividendFlavor = "ordinary" | "special" | "unknown";
+export type IndexReturnVariant = "pr" | "tr" | "ntr" | "unknown";
+
+export type Relevance = "high" | "medium" | "low";
+
+export type SimulatorInput = {
+  eventClass: EventClass;
+  eventFamily: EventFamily;
+  /** Sub-fields — only relevant subsets used per family */
+  rightsItm: RightsItm;
+  rightsSubscriptionKnown: boolean;
+  mnaDealType: MnaDealType;
+  mnaIndexParties: MnaIndexParties;
+  spinoffChildEligible: SpinoffChildEligible;
+  spinoffPhase: SpinoffPhase;
+  dividendFlavor: DividendFlavor;
+  indexReturnVariant: IndexReturnVariant;
+  effectiveDate: string; // YYYY-MM-DD
+  exDate: string;
+  dataAsOf: string; // YYYY-MM-DD
+  missingVendors: VendorId[];
+  presentVendors: VendorId[];
+  notes: string;
+};
+
+export type Hypothesis = {
+  id: string;
+  title: string;
+  explanation: string;
+  relevance: Relevance;
+  appliesToVendors: VendorId[];
+};
+
+export type SimulatorResult = {
+  summary: string;
+  hypotheses: Hypothesis[];
+  nextStepLinks: { label: string; href: string }[];
+  disclaimer: string;
+  rulesVersion: string;
+};

--- a/src/lib/vendors.ts
+++ b/src/lib/vendors.ts
@@ -1,0 +1,26 @@
+/** Canonical vendor list — keep in sync with site copy and simulator UI. */
+export const VENDOR_IDS = [
+  "msci",
+  "sp",
+  "ftse",
+  "stoxx",
+  "solactive",
+  "morningstar",
+  "vettafi",
+] as const;
+
+export type VendorId = (typeof VENDOR_IDS)[number];
+
+export const VENDOR_LABELS: Record<VendorId, string> = {
+  msci: "MSCI",
+  sp: "S&P DJI",
+  ftse: "FTSE Russell",
+  stoxx: "STOXX",
+  solactive: "Solactive",
+  morningstar: "Morningstar",
+  vettafi: "VettaFi",
+};
+
+export function vendorLabel(id: VendorId): string {
+  return VENDOR_LABELS[id];
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Delivers **readability P0** + **site aesthetic** per plan (without editing the attached plan file).

### P0 — Simulator readability
- `xl:flex-row`, narrow rail (`xl:w-40`), short desktop step labels + `title` tooltips, main column `flex-1 basis-0`, `overflow-x-hidden` on the scroll region.
- Vendor step: stacked until **`2xl`** then two columns; short headers + tooltips; vendor chips **`whitespace-nowrap`** + pills.

### Home + vendors
- Hero: **`max-w-7xl`**, asymmetric **`xl:grid-cols-[minmax(0,1fr)_minmax(0,1.35fr)]`**.
- Section shells unified via **`SurfaceSection`** / **`surfaceOuterClass`** ([`src/components/surface-section.tsx`](src/components/surface-section.tsx)).

### Optional plan items (done lightly)
- **Design tokens / helper:** `SurfaceSection` + exported `surfaceOuterClass`.
- **Layout / globals:** `html` **`overflow-x-hidden`**; body **`min-h-dvh`** (with `min-h-screen` fallback).

## Verify

`npm run dev` — vendor step + hero at 1280px+.

## Checks

`npm run build` and `npm run lint` pass.

Latest commit: `0356d5a`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-576b5cc8-8fa7-486c-a1f2-58208cf6fddc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-576b5cc8-8fa7-486c-a1f2-58208cf6fddc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

