### PR TITLE
feat: Vercel-ready Next config (remove static export)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,21 +1,16 @@
-name: Deploy to GitHub Pages
+name: CI
 
 on:
   push:
     branches: [main]
   workflow_dispatch:
 
-permissions:
-  contents: read
-  pages: write
-  id-token: write
-
 concurrency:
-  group: "pages"
-  cancel-in-progress: false
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  build:
+  verify:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -30,23 +25,11 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Lint
+        run: npm run lint
+
+      - name: Typecheck
+        run: npx tsc --noEmit
+
       - name: Build
         run: npm run build
-        env:
-          NEXT_PUBLIC_BASE_PATH: /knowledge-hub
-
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: out
-
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,19 +1,9 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  // Static export for GitHub Pages
-  output: "export",
-  
-  // GitHub Pages is served from /knowledge-hub subdirectory
-  basePath: "/knowledge-hub",
-  
-  // Ensure trailing slashes for static export compatibility
+  // Vercel: no output: "export" — enables Route Handlers / serverless functions
+  // No basePath — app is served from the deployment root
   trailingSlash: true,
-  
-  // Disable image optimization for static export
-  images: {
-    unoptimized: true,
-  },
 };
 
 export default nextConfig;

--- a/src/app/api/test/route.ts
+++ b/src/app/api/test/route.ts
@@ -1,0 +1,7 @@
+import { NextResponse } from "next/server";
+
+export const dynamic = "force-dynamic";
+
+export function GET() {
+  return NextResponse.json({ ok: true, source: "serverless" });
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements `SPECS/VERCEL-MIGRATION.md` for the primary Vercel deployment:

- **`next.config.ts`:** Removed `output: "export"` and `basePath: "/knowledge-hub"` so Route Handlers and serverless functions work on Vercel. Kept `trailingSlash: true` for stable URLs.
- **`src/app/api/test/route.ts`:** Added `GET /api/test` returning JSON with `dynamic = "force-dynamic"` so the route is not statically prerendered — a quick check that the deployment is not static-export-only.
- **`.github/workflows/deploy.yml`:** Replaced the GitHub Pages artifact upload (which required `out/` from static export) with a **CI** job: `npm ci`, lint, `tsc --noEmit`, and `npm run build`.

## Verification (after Vercel import)

1. Merge this PR (or deploy this branch) on the linked Vercel project.
2. Open `https://<your-deployment>/api/test` — expect `200` and body like `{"ok":true,"source":"serverless"}`.

Vercel CLI is not authenticated in the agent environment, so deployment status was not queried from here.

## Note on GitHub Pages

Production hosting is now expected on **Vercel**. The old workflow that published `out/` to GitHub Pages would fail without static export; CI still validates every push to `main`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a2ae96ad-0263-4d06-8c3c-4b25301fddcf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a2ae96ad-0263-4d06-8c3c-4b25301fddcf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

