### PR TITLE
docs: Vercel deployment follow-up (README, agents, migration spec)

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -20,7 +20,7 @@ alwaysApply: true
 
 **Design philosophy:** "Modern, Clean, Smooth, Minimalist" — glassmorphism, bento box layouts, high-contrast typography, dark mode default.
 
-**Live URL:** https://zeimhahnu.github.io/knowledge-hub/
+**Live URL:** https://corporate-action.vercel.app/
 
 ---
 
@@ -166,8 +166,8 @@ Any constraints, dependencies, or technical considerations?
 - Commit messages: `feat:`, `fix:`, `refactor:`, `docs:`, `style:`
 - One logical unit per commit (one component, one fix)
 - Branch: `main` only — no feature branches
-- After every successful commit: GitHub Pages auto-deploys
+- After every successful merge to `main`: Vercel auto-deploys production
 
 ---
 
-*This file is maintained by Lil Claw / Goop. Last updated: 2026-04-18*
+*This file is maintained by Lil Claw / Goop. Last updated: 2026-04-19*

--- a/README.md
+++ b/README.md
@@ -59,17 +59,21 @@ npx tsc --noEmit # TypeScript check
 
 ## Deployment
 
-Pushed to `main` → GitHub Pages auto-deploys to:
-**https://zeimhahnu.github.io/knowledge-hub/**
+Pushed to `main` → **Vercel** builds and deploys the app (Next.js serverless, no static export).
+
+**Production:** https://corporate-action.vercel.app/
+
+GitHub Actions on `main` runs lint, typecheck, and `npm run build` (see `.github/workflows/deploy.yml`).
 
 ## Live Pages
 
-| Page | URL |
+| Page | URL (on production host) |
 |------|-----|
 | Homepage (Decision Tree) | `/` |
 | Vendor Reference | `/vendors/` |
 | ISO CAEV Taxonomy | `/vendors/iso-taxonomy/` |
 | Event Extraction | `/vendors/event-extraction/` |
+| API health check | `/api/test/` |
 
 ## Event Types Covered
 

--- a/SPECS/VERCEL-MIGRATION.md
+++ b/SPECS/VERCEL-MIGRATION.md
@@ -1,50 +1,55 @@
-# NEXT STEPS after Vercel import
+# Vercel migration — status
 
-## Step: Remove static export config
+**Completed (2026-04-19):**
 
-**File:** `next.config.ts`
+- [x] Vercel project linked to this repo
+- [x] `next.config.ts`: removed `output: "export"` and `basePath` (see merged PR #4)
+- [x] Production deploy verified: `/api/test/` returns JSON (`serverless` path works)
+- [x] GitHub Actions: CI on `main` (lint + typecheck + build); GitHub Pages static upload removed
 
-**Current (GitHub Pages):**
+**Production URL:** https://corporate-action.vercel.app/
+
+---
+
+## Reference: what changed (GitHub Pages → Vercel)
+
+### Old (`next.config.ts` for GitHub Pages)
+
 ```ts
 const nextConfig: NextConfig = {
-  output: "export",      // ← REMOVE THIS
-  basePath: "/knowledge-hub",  // ← REMOVE THIS
+  output: "export",
+  basePath: "/knowledge-hub",
   trailingSlash: true,
   images: { unoptimized: true },
 }
 ```
 
-**New (Vercel):**
+### New (Vercel)
+
 ```ts
 const nextConfig: NextConfig = {
-  // No output: "export" — enables serverless functions
-  // No basePath — served from root (corporate-action.vercel.app)
-  
-  images: {
-    // Allow image optimization on Vercel
-    // unoptimized removed — Vercel handles this natively
-  },
+  // No output: "export" — enables Route Handlers / serverless functions
+  // No basePath — served from deployment root
+  trailingSlash: true,
 }
 ```
 
-**What to do:**
-1. Cursor commits this change
-2. git push → Vercel auto-deploys
-3. Verify serverless works with a simple test API route
+Next.js **image optimization** uses the default on Vercel (no `images.unoptimized` needed).
 
-**Test:** After deploy, check if `/api/test` route responds (will 404 if static export still on).
+**Smoke test:** `GET /api/test/` should return `{"ok":true,"source":"serverless"}`. If you still see static-export behavior, `output: "export"` is still set somewhere.
 
 ---
 
 ## Vercel MCP for Cursor
 
 Cursor can use Vercel MCP to:
+
 - Check deployment status
 - View logs
 - Manage environment variables
 - Trigger new deployments
 
-Cursor should `vercel dev` locally to test serverless functions before pushing.
+Use `vercel dev` locally to exercise Route Handlers before pushing.
 
 ---
 

--- a/SPECS/inbox/feature-investor-intelligence-browser.md
+++ b/SPECS/inbox/feature-investor-intelligence-browser.md
@@ -6,6 +6,8 @@
 > Feature ID: `investor-intelligence-browser-v1`
 > GitHub Issue: TO BE CREATED
 
+> **Hosting (2026-04-19):** Production is **Vercel** (`https://corporate-action.vercel.app/`). Next.js **Route Handlers** (`src/app/api/...`) are supported. GitHub Actions on `main` runs CI only; merge to `main` triggers **Vercel** deploy. See `SPECS/VERCEL-MIGRATION.md`.
+
 ---
 
 ## Context
@@ -171,7 +173,7 @@ import 'tippy.js/dist/tippy.css'
 | 5 | Issue moved to "In Progress" |
 | 6 | Cursor implements → git push |
 | 7 | GitHub Actions CI runs lint + tsc |
-| 8 | On merge → GitHub Pages deploys |
+| 8 | On merge to `main` → **Vercel** production deploy |
 | 9 | Issue closed, PRD archived |
 
 ---

--- a/SPECS/outbox/PRD-TEMPLATE.md
+++ b/SPECS/outbox/PRD-TEMPLATE.md
@@ -67,5 +67,5 @@ List each component to be built/modified:
 2. `npx tsc --noEmit` — TypeScript passes
 3. `npm run lint` — ESLint passes
 4. Browser test at localhost:3000
-5. Git commit and push → GitHub Pages deploys
-6. Confirm live at https://zeimhahnu.github.io/knowledge-hub/
+5. Git commit and push → merge to `main` → **Vercel** production deploys
+6. Confirm live at https://corporate-action.vercel.app/ (see `SPECS/VERCEL-MIGRATION.md`)

--- a/SPECS/outbox/investor-intelligence-browser-prd.md
+++ b/SPECS/outbox/investor-intelligence-browser-prd.md
@@ -29,7 +29,7 @@ This extends the knowledge hub from **index-vendor methodology** toward **single
 
 ### Layout & Structure
 
-1. **Route:** New page under the app, e.g. `/investors/` (exact path TBD with Goop; must respect `basePath: /knowledge-hub` for static assets and internal links).
+1. **Route:** New page under the app, e.g. `/investors/` (exact path TBD with Goop). Production is served from the **site root** on Vercel (no `basePath`; use normal `next/link` and `/` paths).
 2. **Top:** Search field (ticker) + submit; optional exchange suffix handling documented in tech notes.
 3. **Header strip:** Symbol, company name (if available), last price / day change (if available), sector / exchange chips — **one row**, truncates gracefully on mobile.
 4. **Body (card stack):**
@@ -70,22 +70,20 @@ This extends the knowledge hub from **index-vendor methodology** toward **single
 
 ## Technical Specification
 
-### Critical platform constraint (must resolve before build)
+### Hosting & data runtime (updated 2026-04-19)
 
-The app is configured for **`output: "export"`** (GitHub Pages). **Static export does not ship Next.js Route Handlers or server runtime.** The inbox sketch’s pattern:
+**Production:** **Vercel** — Next.js **serverless Route Handlers** are supported (no `output: "export"`). Smoke route: `GET /api/test/`. Details: `SPECS/VERCEL-MIGRATION.md`.
 
-`src/app/api/corporate-actions/[ticker]/route.ts` + **server `exec` of Python** — **will not deploy** on the current GitHub Pages model.
-
-**PRD decision (pick one in implementation — requires Alex/Goop sign-off):**
+The inbox sketch still proposes **`exec` of a local Python `yfinance` script** from a Route Handler. That pattern is **not** a good fit for Vercel’s default Node serverless runtime (no bundled Python, subprocess/child-process constraints, cold starts). **Pick one data path before build** (Alex/Goop sign-off):
 
 | Option | Pros | Cons |
 |--------|------|------|
-| **A. Separate lightweight backend** (Worker / small VPS / other host) exposing `GET /quote?ticker=` used by the static site | Real `yfinance`, caching, secrets isolated | Second deployable, CORS, auth/rate limits |
-| **B. Move hub hosting** to a platform that runs Next serverless functions | Single repo, API routes possible | Leaves current GH Pages-only workflow |
-| **C. Client-callable JSON provider** (official vendor / exchange / paid API) | Fits static site | Keys, cost, licensing, tos |
-| **D. Document as “local-only demo”** | Fast prototype via `npm run dev` + local API | Not on production GH Pages |
+| **A. Separate backend** (Cloudflare Worker, small VPS, etc.) with `GET /quote?ticker=` | Real `yfinance` or any stack, caching, secrets isolated | Second service, CORS, auth/rate limits |
+| **B. Next Route Handler + HTTP** to a hosted quotes API (vendor / exchange / paid) | Single Vercel deploy for the app | Keys, cost, licensing, ToS |
+| **C. Vercel-native data** (e.g. serverless-friendly HTTP client only; no Python subprocess) | One repo, fits current deploy | May not be `yfinance` as-is |
+| **D. Local-only demo** | Fast prototype via `npm run dev` + local API | Not on production |
 
-**Recommendation:** **Option A** or **B** for anything calling Python subprocesses; document chosen path in README and Issue #3 before coding.
+**Recommendation:** Prefer **A** or **B** for `yfinance`-equivalent data unless we adopt a JS-only market data client; document the chosen path in README and Issue #3 before coding.
 
 ### Data layer (once runtime exists)
 
@@ -130,13 +128,13 @@ type InvestorTickerResponse = {
 
 ## Implementation Plan
 
-1. **Architecture gate:** Confirm Option A/B/C/D with Alex/Goop; update Issue #3 + README deployment section with the chosen runtime for investor data.
+1. **Architecture gate:** Confirm Option A/B/C/D with Alex/Goop; update Issue #3 + README with the chosen **production** data path (Vercel hosts the app; data may still be a separate API).
 2. **Scaffold page** `/investors/` with empty states + disclaimer + navigation.
 3. **Implement data client** against the chosen API contract; strict TypeScript types + Zod parse if JSON from Python.
 4. **Build UI cards** per design spec; Framer Motion polish; responsive pass.
 5. **JargonTip** coverage for all bolded jargon in UI.
 6. **QA:** invalid ticker, illiquid names, missing calendar; `npm run lint`, `npx tsc --noEmit`.
-7. **Post-approval:** merge to `main`, verify live URL path with `basePath`.
+7. **Post-approval:** merge to `main`, verify on **Vercel** production URL (paths from site root, e.g. `/investors/`).
 
 ---
 
@@ -151,7 +149,7 @@ type InvestorTickerResponse = {
 - [ ] **Responsive** layouts at `sm` / `md` breakpoints.
 - [ ] **Accessible:** focus order, tooltips, form labels, live region or polite announcement for errors (exact pattern in implementation).
 - [ ] **CI:** `npm run lint` and `npx tsc --noEmit` pass.
-- [ ] **Documentation:** README + Issue #3 updated with **how production fetches data** given static export constraints.
+- [ ] **Documentation:** README + Issue #3 updated with **how production fetches data** on Vercel (Route Handlers vs external API).
 
 ---
 
@@ -161,7 +159,7 @@ type InvestorTickerResponse = {
 2. `npx tsc --noEmit` — passes.
 3. `npm run lint` — passes.
 4. Manual browser matrix: valid ticker, invalid ticker, ticker with no dividends, ticker with sparse calendar.
-5. After merge: confirm **production** behaviour matches chosen architecture (GH Pages static vs hosted API).
+5. After merge: confirm **production** on Vercel matches the chosen data architecture (Next API vs external backend).
 
 ---
 

--- a/VENDOR_HANDOFF.md
+++ b/VENDOR_HANDOFF.md
@@ -60,8 +60,9 @@ knowledge-hub/
 
 ## Deployment
 
-Push to `main` → GitHub Pages auto-deploys to:
-**https://zeimhahnu.github.io/knowledge-hub/**
+Push to `main` → Vercel auto-deploys production:
+
+**https://corporate-action.vercel.app/**
 
 ## Commands
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Finishes post-Vercel documentation so Goop/Lil Claw and future PRDs match production.

## Changes

- **README.md**, **.cursorrules**, **VENDOR_HANDOFF.md** — Vercel production URL and deploy flow.
- **SPECS/VERCEL-MIGRATION.md** — Completed checklist + reference (historical GitHub Pages vs Vercel).
- **SPECS/outbox/PRD-TEMPLATE.md** — Verification steps: Vercel URL + merge to `main`.
- **SPECS/inbox/feature-investor-intelligence-browser.md** — Hosting banner + workflow step 8 → Vercel deploy.
- **SPECS/outbox/investor-intelligence-browser-prd.md** — Removed obsolete GitHub Pages/static-export framing; routes from site root; data-runtime options updated for Vercel (Python `exec` vs separate API / hosted JSON).

## Merge note

Docs and specs only; safe to merge anytime.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a2ae96ad-0263-4d06-8c3c-4b25301fddcf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a2ae96ad-0263-4d06-8c3c-4b25301fddcf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

