### PR TITLE
docs: OpenClaw/Goop Vercel handoff + fix stale GitHub Pages wording

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -55,9 +55,9 @@ Lil Claw → reads PRD → Telegram → Alex: "Here's the PRD, approve?"
          ↓
 Alex → "approved" → Goop moves to SPECS/approved/
          ↓
-Cursor → implements → git push → GitHub Pages deploys
+Cursor → implements → merge to `main` → **Vercel** production deploys
          ↓
-Goop → monitors GitHub → Telegram → Alex: "Deployed! [URL]"
+Goop → monitors Vercel / GitHub → Telegram → Alex: "Deployed! [URL]"
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ Pushed to `main` → **Vercel** builds and deploys the app (Next.js serverless, 
 
 GitHub Actions on `main` runs lint, typecheck, and `npm run build` (see `.github/workflows/deploy.yml`).
 
+**Agent handoff (Goop / OpenClaw):** `SPECS/HANDOFF-OPENCLAW-GOOP-VERCEL.md`
+
 ## Live Pages
 
 | Page | URL (on production host) |

--- a/SPECS/HANDOFF-OPENCLAW-GOOP-VERCEL.md
+++ b/SPECS/HANDOFF-OPENCLAW-GOOP-VERCEL.md
@@ -1,0 +1,33 @@
+# Handoff: OpenClaw / Goop — hosting & where to read next
+
+**Read this file first** when picking up the knowledge-hub repo after the 2026-04 hosting move.
+
+## Current truth (do not contradict in new specs)
+
+| Topic | Fact |
+|--------|------|
+| **Production app** | https://corporate-action.vercel.app/ |
+| **Deploy trigger** | Merge (or push) to `main` on GitHub → **Vercel** builds and deploys the Next.js app |
+| **GitHub Actions** | **CI only** on `main` — `npm ci`, lint, `tsc`, `npm run build` (`.github/workflows/deploy.yml`). It does **not** publish a static site. |
+| **Next config** | `next.config.ts` must **not** use `output: "export"` or `basePath: "/knowledge-hub"` — that was the old GitHub Pages static export. Restoring those **breaks** serverless Route Handlers on Vercel. |
+| **Smoke check** | `GET https://corporate-action.vercel.app/api/test/` → JSON `{"ok":true,"source":"serverless"}`. If that 404s or returns static HTML, something reverted to static export. |
+
+## Canonical docs (read order)
+
+1. **`SPECS/VERCEL-MIGRATION.md`** — What changed, checklist, old vs new `next.config.ts`.
+2. **`README.md`** — Deployment section (Vercel + CI).
+3. **`.cursorrules`** — Live URL + handoff diagram (must say Vercel, not GitHub Pages).
+
+## For new features / PRDs
+
+- Use **paths from site root** (e.g. `/vendors/`, `/investors/`). There is **no** `basePath` in production.
+- In verification steps, say **merge to `main` → confirm on Vercel**, not “GitHub Pages deploys”.
+- If a feature needs **Python subprocess / yfinance on disk**, that is **not** assumed to work inside Vercel’s default Node function — call that out and choose an external API or worker (see `SPECS/outbox/investor-intelligence-browser-prd.md`).
+
+## Legacy URL
+
+**https://zeimhahnu.github.io/knowledge-hub/** may still exist as an old static mirror or 404; **product decisions and QA use the Vercel URL above.**
+
+---
+
+*Session handoff — Cursor — 2026-04-19*

--- a/SPECS/VERCEL-MIGRATION.md
+++ b/SPECS/VERCEL-MIGRATION.md
@@ -9,6 +9,8 @@
 
 **Production URL:** https://corporate-action.vercel.app/
 
+**OpenClaw / Goop quick start:** read **`SPECS/HANDOFF-OPENCLAW-GOOP-VERCEL.md`** first (one-page handoff + read order).
+
 ---
 
 ## Reference: what changed (GitHub Pages → Vercel)

--- a/SPECS/archive/feature-bloomberg-output.md
+++ b/SPECS/archive/feature-bloomberg-output.md
@@ -131,4 +131,4 @@ Display count: `🔴 ×2  🟡 ×1`
 - [ ] Signal icons (🔴🟡⚪) appear in summary
 - [ ] No new explanatory paragraphs added — only tightened existing content
 - [ ] TypeScript compiles, ESLint passes
-- [ ] Git push → GitHub Pages deploys
+- [ ] Merge to `main` → Vercel production deploys (see `SPECS/HANDOFF-OPENCLAW-GOOP-VERCEL.md`)

--- a/SPECS/archive/feature-tippy-tooltips.md
+++ b/SPECS/archive/feature-tippy-tooltips.md
@@ -128,4 +128,4 @@ Add to `src/app/globals.css`:
 - [ ] 200ms delay, fade animation
 - [ ] Keyboard accessible (tab to term, Enter to show tooltip)
 - [ ] TypeScript compiles, ESLint passes
-- [ ] Git push → GitHub Pages deploys
+- [ ] Merge to `main` → Vercel production deploys (see `SPECS/HANDOFF-OPENCLAW-GOOP-VERCEL.md`)

--- a/SPECS/inbox/feature-bloomberg-output.md
+++ b/SPECS/inbox/feature-bloomberg-output.md
@@ -131,4 +131,4 @@ Display count: `🔴 ×2  🟡 ×1`
 - [ ] Signal icons (🔴🟡⚪) appear in summary
 - [ ] No new explanatory paragraphs added — only tightened existing content
 - [ ] TypeScript compiles, ESLint passes
-- [ ] Git push → GitHub Pages deploys
+- [ ] Merge to `main` → Vercel production deploys (see `SPECS/HANDOFF-OPENCLAW-GOOP-VERCEL.md`)

--- a/SPECS/inbox/feature-tippy-tooltips.md
+++ b/SPECS/inbox/feature-tippy-tooltips.md
@@ -128,4 +128,4 @@ Add to `src/app/globals.css`:
 - [ ] 200ms delay, fade animation
 - [ ] Keyboard accessible (tab to term, Enter to show tooltip)
 - [ ] TypeScript compiles, ESLint passes
-- [ ] Git push → GitHub Pages deploys
+- [ ] Merge to `main` → Vercel production deploys (see `SPECS/HANDOFF-OPENCLAW-GOOP-VERCEL.md`)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Complete check (hosting)

- **`origin/main` `next.config.ts`:** No `output: "export"`, no `basePath` — Vercel serverless remains correct. Re-adding those would affect the **next** Vercel build (API routes would stop behaving as serverless), not the currently running deployment until a new deploy runs.
- **Live smoke:** `https://corporate-action.vercel.app/api/test/` returns `{"ok":true,"source":"serverless"}`.

## What was wrong in-repo

- **`.cursorrules`** handoff diagram still said “GitHub Pages deploys” (cosmetic for agents, confusing for Goop).
- New **Tippy / Bloomberg** specs (inbox + archive) still had “Git push → GitHub Pages deploys” in acceptance criteria.

## What this PR adds

- **`SPECS/HANDOFF-OPENCLAW-GOOP-VERCEL.md`** — One-page handoff for OpenClaw/Goop: production URL, CI vs Vercel, what not to revert, read order, legacy `github.io` note.
- Links from **`README.md`** and **`SPECS/VERCEL-MIGRATION.md`** to that handoff file.

## For Goop on the VPS

After merge: `git pull` on the repo, then read **`SPECS/HANDOFF-OPENCLAW-GOOP-VERCEL.md`** first (then `VERCEL-MIGRATION.md` if they need migration detail).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a2ae96ad-0263-4d06-8c3c-4b25301fddcf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a2ae96ad-0263-4d06-8c3c-4b25301fddcf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

