### PR TITLE
feat: Investor intelligence browser (/investors + quote API)

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ GitHub Actions on `main` runs lint, typecheck, and `npm run build` (see `.github
 | ISO CAEV Taxonomy | `/vendors/iso-taxonomy/` |
 | Event Extraction | `/vendors/event-extraction/` |
 | API health check | `/api/test/` |
+| Investor snapshot (by ticker) | `/investors/` |
 
 ## Event Types Covered
 

--- a/src/app/api/investors/quote/route.ts
+++ b/src/app/api/investors/quote/route.ts
@@ -1,0 +1,51 @@
+import { NextResponse } from "next/server";
+
+import { buildInvestorPayload, normalizeTicker } from "@/lib/investors/yahoo-finance";
+
+export const dynamic = "force-dynamic";
+
+const TTL_MS = 5 * 60 * 1000;
+const cache = new Map<string, { at: number; body: unknown }>();
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const raw = searchParams.get("ticker") ?? "";
+  const key = normalizeTicker(raw);
+
+  if (!key) {
+    return NextResponse.json(
+      { error: "Missing ticker", code: "MISSING" },
+      { status: 400 },
+    );
+  }
+
+  const now = Date.now();
+  const hit = cache.get(key);
+  if (hit && now - hit.at < TTL_MS) {
+    return NextResponse.json(hit.body);
+  }
+
+  try {
+    const body = await buildInvestorPayload(raw);
+    cache.set(key, { at: now, body });
+    return NextResponse.json(body);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : "UNKNOWN";
+    if (msg === "INVALID_TICKER") {
+      return NextResponse.json(
+        { error: "Invalid ticker symbol", code: "INVALID_TICKER" },
+        { status: 400 },
+      );
+    }
+    if (msg === "NOT_FOUND") {
+      return NextResponse.json(
+        { error: "Symbol not found or no data", code: "NOT_FOUND" },
+        { status: 404 },
+      );
+    }
+    return NextResponse.json(
+      { error: "Upstream data unavailable", code: "UPSTREAM" },
+      { status: 502 },
+    );
+  }
+}

--- a/src/app/investors/layout.tsx
+++ b/src/app/investors/layout.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+
+export const metadata: Metadata = {
+  title: "Investor intelligence — Index Vendor Intelligence",
+  description:
+    "Quick dividend, split, and calendar snapshot by ticker. Delayed market data for orientation only.",
+};
+
+export default function InvestorsLayout({ children }: { children: ReactNode }) {
+  return children;
+}

--- a/src/app/investors/page.tsx
+++ b/src/app/investors/page.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import Link from "next/link";
+import { motion, useReducedMotion } from "framer-motion";
+import { ArrowLeftIcon, LineChartIcon } from "lucide-react";
+
+import { SurfaceSection } from "@/components/surface-section";
+import { InvestorSearchBar } from "@/components/investors/investor-search-bar";
+import { InvestorQuoteStrip } from "@/components/investors/investor-quote-strip";
+import { DividendSummaryCard } from "@/components/investors/dividend-summary-card";
+import { SplitHistoryCard } from "@/components/investors/split-history-card";
+import { UpcomingEventsCard } from "@/components/investors/upcoming-events-card";
+import type { InvestorTickerResponse } from "@/lib/investors/types";
+
+export default function InvestorsPage() {
+  const reduceMotion = useReducedMotion();
+  const [input, setInput] = useState("");
+  const [activeTicker, setActiveTicker] = useState("");
+  const [data, setData] = useState<InvestorTickerResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const runSearch = useCallback(async (ticker: string) => {
+    const t = ticker.trim();
+    if (!t) return;
+    setLoading(true);
+    setError(null);
+    setData(null);
+    setActiveTicker(t);
+    try {
+      const res = await fetch(
+        `/api/investors/quote/?ticker=${encodeURIComponent(t)}`,
+        { cache: "no-store", method: "GET" },
+      );
+      const json = (await res.json()) as InvestorTickerResponse & {
+        error?: string;
+        code?: string;
+      };
+      if (!res.ok) {
+        setError(json.error ?? "Request failed");
+        return;
+      }
+      setData(json);
+    } catch {
+      setError("Network error. Try again.");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  return (
+    <main className="min-h-screen bg-background text-foreground">
+      <div className="border-b border-border bg-card/30">
+        <div className="mx-auto max-w-4xl px-6 py-8">
+          <Link
+            href="/"
+            className="mb-6 inline-flex items-center gap-2 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
+          >
+            <ArrowLeftIcon className="h-4 w-4" aria-hidden />
+            Back to hub
+          </Link>
+          <div className="mb-2 inline-flex items-center gap-2 rounded-full border border-border bg-muted/40 px-3 py-1 text-xs font-medium text-muted-foreground">
+            <LineChartIcon className="h-3.5 w-3.5 text-primary" aria-hidden />
+            Investor snapshot
+          </div>
+          <h1 className="mb-3 text-3xl font-semibold tracking-tight">Investor intelligence</h1>
+          <p className="max-w-prose text-sm text-muted-foreground">
+            Enter a US-listed symbol for a quick read on recent dividends, splits, and
+            calendar hints. Data is third-party and delayed — not advice, not a substitute
+            for your broker or official notices. For{" "}
+            <Link href="/vendors/" className="text-primary underline-offset-4 hover:underline">
+              index vendor methodology
+            </Link>
+            , use the vendor reference.
+          </p>
+        </div>
+      </div>
+
+      <div className="mx-auto max-w-4xl px-6 py-10">
+        <SurfaceSection padding="comfortable" className="mb-8">
+          <InvestorSearchBar
+            value={input}
+            onChange={setInput}
+            onSubmit={() => runSearch(input)}
+            loading={loading}
+          />
+          <p className="mt-4 text-xs text-muted-foreground">
+            Try <button type="button" className="text-primary hover:underline" onClick={() => { setInput("AAPL"); void runSearch("AAPL"); }}>AAPL</button>
+            {", "}
+            <button type="button" className="text-primary hover:underline" onClick={() => { setInput("MSFT"); void runSearch("MSFT"); }}>MSFT</button>
+            {", or "}
+            <button type="button" className="text-primary hover:underline" onClick={() => { setInput("JPM"); void runSearch("JPM"); }}>JPM</button>
+            .
+          </p>
+        </SurfaceSection>
+
+        {error && (
+          <div
+            role="alert"
+            className="mb-8 rounded-xl border border-destructive/40 bg-destructive/10 px-4 py-3 text-sm text-destructive"
+          >
+            {error}
+          </div>
+        )}
+
+        {(loading || data) && (
+          <motion.div
+            initial={reduceMotion ? false : { opacity: 0, y: 8 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: reduceMotion ? 0 : 0.25 }}
+            className="space-y-6"
+          >
+            <InvestorQuoteStrip
+              ticker={data?.ticker ?? activeTicker.toUpperCase()}
+              quote={data?.quote}
+              loading={loading}
+            />
+            <div className="grid gap-6 md:grid-cols-1">
+              <DividendSummaryCard
+                dividends={data?.dividends ?? []}
+                dividendRate={data?.metrics?.dividendRate}
+                dividendYield={data?.metrics?.dividendYield}
+                loading={loading}
+              />
+              <div className="grid gap-6 sm:grid-cols-2">
+                <SplitHistoryCard splits={data?.splits ?? []} loading={loading} />
+                <UpcomingEventsCard calendar={data?.calendar} loading={loading} />
+              </div>
+            </div>
+            {data && data.warnings.length > 0 && (
+              <ul className="text-xs text-muted-foreground">
+                {data.warnings.map((w) => (
+                  <li key={w}>· {w}</li>
+                ))}
+              </ul>
+            )}
+          </motion.div>
+        )}
+
+        <footer className="mt-12 border-t border-border pt-8 text-xs text-muted-foreground">
+          <p className="max-w-prose leading-relaxed">
+            Quotes and events are aggregated from public market data feeds and may be
+            incomplete or delayed. This page is for orientation only.
+          </p>
+        </footer>
+      </div>
+    </main>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -433,7 +433,7 @@ export default function Home() {
       {/* ── Quick Links ─────────────────────────────────────────────────── */}
       <section className="mx-auto max-w-6xl border-t border-border px-6 py-12">
         <SurfaceSection padding="compact">
-        <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
           <Link
             href="/vendors/"
             className="rounded-2xl border border-border bg-card p-5 transition-all hover:border-primary/50 hover:bg-muted/50"
@@ -452,6 +452,16 @@ export default function Home() {
             <div className="mb-1 text-sm font-semibold">ISO Taxonomy</div>
             <p className="text-xs text-muted-foreground">
               ISO 20022 CAEV codes mapped to SWIFT MT564 and vendor terminology
+            </p>
+          </Link>
+          <Link
+            href="/investors/"
+            className="rounded-2xl border border-border bg-card p-5 transition-all hover:border-primary/50 hover:bg-muted/50"
+          >
+            <GlobeIcon className="mb-3 h-5 w-5 text-primary" />
+            <div className="mb-1 text-sm font-semibold">Investor snapshot</div>
+            <p className="text-xs text-muted-foreground">
+              Dividends, splits, and calendar hints by ticker (delayed data)
             </p>
           </Link>
           <div className="rounded-2xl border border-border bg-card p-5">

--- a/src/components/investors/dividend-summary-card.tsx
+++ b/src/components/investors/dividend-summary-card.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import type { InvestorDividendRow } from "@/lib/investors/types";
+import { dividendTrend, formatUsd } from "@/lib/investors/format";
+import { GlossaryTerm } from "@/components/ui/glossary-term";
+
+interface Props {
+  dividends: InvestorDividendRow[];
+  dividendRate?: number;
+  dividendYield?: number;
+  loading?: boolean;
+}
+
+function SkeletonCard() {
+  return (
+    <div className="animate-pulse rounded-xl border border-border bg-card/60 p-6">
+      <div className="mb-4 h-4 w-40 rounded bg-muted" />
+      <div className="space-y-2">
+        <div className="h-3 w-full rounded bg-muted/70" />
+        <div className="h-3 w-[80%] rounded bg-muted/70" />
+      </div>
+    </div>
+  );
+}
+
+export function DividendSummaryCard({
+  dividends,
+  dividendRate,
+  dividendYield,
+  loading,
+}: Props) {
+  if (loading) return <SkeletonCard />;
+
+  const trend = dividendTrend(dividends);
+  const trendLabel =
+    trend === "up" ? "↑" : trend === "down" ? "↓" : trend === "flat" ? "—" : "—";
+
+  return (
+    <div className="rounded-xl border border-border bg-card/80 p-6">
+      <h3 className="mb-4 text-sm font-semibold text-foreground">Dividend history</h3>
+      {dividends.length === 0 ? (
+        <p className="text-sm text-muted-foreground">No recent dividends in range.</p>
+      ) : (
+        <>
+          <p className="mb-3 text-sm tabular-nums text-foreground">
+            {dividends
+              .map((d) => formatUsd(d.amount))
+              .join(" → ")}
+            <span className="ml-2 text-muted-foreground">({trendLabel} cadence)</span>
+          </p>
+          <div className="flex flex-wrap gap-4 text-sm tabular-nums">
+            {dividendRate != null && (
+              <span className="text-muted-foreground">
+                <GlossaryTerm
+                  term="Dividend rate"
+                  definition="Annualized cash dividend per share, when reported by the data source."
+                >
+                  Rate
+                </GlossaryTerm>
+                :{" "}
+                <span className="font-medium text-foreground">{formatUsd(dividendRate)}/yr</span>
+              </span>
+            )}
+            {dividendYield != null && (
+              <span className="text-muted-foreground">
+                <GlossaryTerm
+                  term="Dividend yield"
+                  definition="Annual dividend divided by the latest price, as a percentage. Delayed snapshot."
+                >
+                  Yield
+                </GlossaryTerm>
+                :{" "}
+                <span className="font-medium text-foreground">{dividendYield.toFixed(2)}%</span>
+              </span>
+            )}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/components/investors/investor-quote-strip.tsx
+++ b/src/components/investors/investor-quote-strip.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import type { InvestorQuote } from "@/lib/investors/types";
+import { formatPct, formatUsd } from "@/lib/investors/format";
+
+interface Props {
+  ticker: string;
+  quote?: InvestorQuote;
+  loading?: boolean;
+}
+
+function Skeleton() {
+  return (
+    <div className="animate-pulse rounded-xl border border-border bg-card/60 p-4">
+      <div className="mb-2 h-6 w-32 rounded bg-muted" />
+      <div className="h-4 w-48 rounded bg-muted/80" />
+    </div>
+  );
+}
+
+export function InvestorQuoteStrip({ ticker, quote, loading }: Props) {
+  if (loading) return <Skeleton />;
+
+  return (
+    <div className="rounded-xl border border-border bg-card/80 p-4">
+      <div className="flex flex-wrap items-baseline gap-2 gap-y-1">
+        <span className="text-2xl font-semibold tracking-tight text-foreground">{ticker}</span>
+        {quote?.name && (
+          <span className="text-sm text-muted-foreground">· {quote.name}</span>
+        )}
+      </div>
+      <div className="mt-2 flex flex-wrap items-center gap-2 text-sm tabular-nums">
+        {quote?.price != null && (
+          <span className="font-medium text-foreground">{formatUsd(quote.price)}</span>
+        )}
+        {quote?.changePct != null && (
+          <span
+            className={
+              quote.changePct > 0
+                ? "text-emerald-500"
+                : quote.changePct < 0
+                  ? "text-destructive"
+                  : "text-muted-foreground"
+            }
+          >
+            {formatPct(quote.changePct)}
+          </span>
+        )}
+        {quote?.sector && (
+          <span className="rounded-full border border-border bg-muted/40 px-2 py-0.5 text-xs font-medium text-muted-foreground">
+            {quote.sector}
+          </span>
+        )}
+        {quote?.exchange && (
+          <span className="rounded-full border border-border bg-muted/40 px-2 py-0.5 text-xs text-muted-foreground">
+            {quote.exchange}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/investors/investor-search-bar.tsx
+++ b/src/components/investors/investor-search-bar.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+interface Props {
+  value: string;
+  onChange: (v: string) => void;
+  onSubmit: () => void;
+  loading: boolean;
+  disabled?: boolean;
+}
+
+export function InvestorSearchBar({
+  value,
+  onChange,
+  onSubmit,
+  loading,
+  disabled,
+}: Props) {
+  return (
+    <form
+      className="flex flex-col gap-3 sm:flex-row sm:items-end"
+      onSubmit={(e) => {
+        e.preventDefault();
+        onSubmit();
+      }}
+    >
+      <div className="min-w-0 flex-1">
+        <label htmlFor="investor-ticker" className="mb-2 block text-sm font-medium text-foreground">
+          Ticker symbol
+        </label>
+        <input
+          id="investor-ticker"
+          name="ticker"
+          type="text"
+          inputMode="text"
+          autoComplete="off"
+          placeholder="e.g. AAPL, MSFT, BRK-B"
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          disabled={disabled || loading}
+          className="h-12 w-full rounded-xl border border-border bg-background px-4 text-base text-foreground outline-none ring-primary/40 transition-shadow placeholder:text-muted-foreground focus-visible:ring-2 disabled:opacity-50"
+        />
+      </div>
+      <button
+        type="submit"
+        disabled={disabled || loading || !value.trim()}
+        className="inline-flex h-12 min-w-[120px] shrink-0 items-center justify-center rounded-xl bg-primary px-6 text-sm font-semibold text-primary-foreground transition-colors hover:bg-primary/90 disabled:pointer-events-none disabled:opacity-40"
+      >
+        {loading ? "Loading…" : "Search"}
+      </button>
+    </form>
+  );
+}

--- a/src/components/investors/split-history-card.tsx
+++ b/src/components/investors/split-history-card.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import type { InvestorSplitRow } from "@/lib/investors/types";
+import { GlossaryTerm } from "@/components/ui/glossary-term";
+
+interface Props {
+  splits: InvestorSplitRow[];
+  loading?: boolean;
+}
+
+function SkeletonCard() {
+  return (
+    <div className="animate-pulse rounded-xl border border-border bg-card/60 p-6">
+      <div className="mb-4 h-4 w-36 rounded bg-muted" />
+      <div className="space-y-2">
+        <div className="h-3 w-full rounded bg-muted/70" />
+        <div className="h-3 w-[66%] rounded bg-muted/70" />
+      </div>
+    </div>
+  );
+}
+
+export function SplitHistoryCard({ splits, loading }: Props) {
+  if (loading) return <SkeletonCard />;
+
+  return (
+    <div className="rounded-xl border border-border bg-card/80 p-6">
+      <h3 className="mb-4 text-sm font-semibold text-foreground">
+        <GlossaryTerm
+          term="Stock split"
+          definition="Company increases share count and reduces price by a set ratio (e.g. 4:1 = four shares for each old share at one-quarter the price)."
+        >
+          Stock splits
+        </GlossaryTerm>
+      </h3>
+      {splits.length === 0 ? (
+        <p className="text-sm text-muted-foreground">No splits in chart range.</p>
+      ) : (
+        <ul className="space-y-2 text-sm tabular-nums text-foreground">
+          {splits.map((s) => (
+            <li key={`${s.date}-${s.ratio}`}>
+              <span className="text-muted-foreground">{s.date}</span>
+              <span className="mx-2 text-border">—</span>
+              <span className="font-medium">{s.ratio}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/components/investors/upcoming-events-card.tsx
+++ b/src/components/investors/upcoming-events-card.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import type { InvestorCalendar } from "@/lib/investors/types";
+import { daysUntil } from "@/lib/investors/format";
+import { GlossaryTerm } from "@/components/ui/glossary-term";
+import { CalendarIcon } from "lucide-react";
+
+interface Props {
+  calendar?: InvestorCalendar;
+  loading?: boolean;
+}
+
+function SkeletonCard() {
+  return (
+    <div className="animate-pulse rounded-xl border border-border bg-card/60 p-6">
+      <div className="mb-4 h-4 w-44 rounded bg-muted" />
+      <div className="h-3 w-full rounded bg-muted/70" />
+    </div>
+  );
+}
+
+function Row({
+  label,
+  term,
+  definition,
+  date,
+}: {
+  label: string;
+  term: string;
+  definition: string;
+  date?: string;
+}) {
+  const d = daysUntil(date);
+  return (
+    <div className="flex flex-wrap items-baseline gap-2 text-sm">
+      <CalendarIcon className="h-4 w-4 shrink-0 text-primary" aria-hidden />
+      <GlossaryTerm term={term} definition={definition}>
+        <span className="font-medium text-foreground">{label}</span>
+      </GlossaryTerm>
+      <span className="text-muted-foreground">:</span>
+      {date ? (
+        <>
+          <span className="tabular-nums text-foreground">{date}</span>
+          {d != null && (
+            <span className="text-xs text-muted-foreground">({d === 0 ? "today" : `in ${d} day${d === 1 ? "" : "s"}`})</span>
+          )}
+        </>
+      ) : (
+        <span className="text-muted-foreground">—</span>
+      )}
+    </div>
+  );
+}
+
+export function UpcomingEventsCard({ calendar, loading }: Props) {
+  if (loading) return <SkeletonCard />;
+
+  return (
+    <div className="rounded-xl border border-border bg-card/80 p-6">
+      <h3 className="mb-4 text-sm font-semibold text-foreground">Upcoming</h3>
+      <div className="space-y-3">
+        <Row
+          label="Ex-dividend"
+          term="Ex-dividend date"
+          definition="First date the stock trades without the declared dividend; buyers on or after this date do not receive that payment."
+          date={calendar?.exDividendDate}
+        />
+        <Row
+          label="Earnings"
+          term="Earnings date"
+          definition="When the company is scheduled to report quarterly results, if provided by the data source."
+          date={calendar?.earningsDate}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/lib/investors/format.ts
+++ b/src/lib/investors/format.ts
@@ -1,0 +1,32 @@
+export function formatUsd(n: number): string {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 4,
+  }).format(n);
+}
+
+export function formatPct(n: number): string {
+  const sign = n > 0 ? "+" : "";
+  return `${sign}${n.toFixed(2)}%`;
+}
+
+/** Days from today to ISO date string (UTC midnight); undefined if invalid/past. */
+export function daysUntil(iso?: string): number | undefined {
+  if (!iso) return undefined;
+  const target = new Date(`${iso}T12:00:00Z`).getTime();
+  if (!Number.isFinite(target)) return undefined;
+  const start = new Date();
+  start.setUTCHours(0, 0, 0, 0);
+  const diff = Math.ceil((target - start.getTime()) / (1000 * 60 * 60 * 24));
+  return diff >= 0 ? diff : undefined;
+}
+
+export function dividendTrend(divs: { amount: number }[]): "up" | "down" | "flat" | "—" {
+  if (divs.length < 2) return "—";
+  const a = divs[0]!.amount;
+  const b = divs[divs.length - 1]!.amount;
+  if (a > b * 1.0001) return "up";
+  if (a < b * 0.9999) return "down";
+  return "flat";
+}

--- a/src/lib/investors/types.ts
+++ b/src/lib/investors/types.ts
@@ -1,0 +1,29 @@
+/** DTO returned by `GET /api/investors/quote` (Yahoo Finance–derived, delayed). */
+
+export type InvestorDividendRow = { date: string; amount: number };
+
+export type InvestorSplitRow = { date: string; ratio: string };
+
+export type InvestorQuote = {
+  name?: string;
+  price?: number;
+  changePct?: number;
+  sector?: string;
+  exchange?: string;
+};
+
+export type InvestorCalendar = {
+  exDividendDate?: string;
+  earningsDate?: string;
+};
+
+export type InvestorTickerResponse = {
+  ticker: string;
+  fetchedAt: string;
+  quote?: InvestorQuote;
+  dividends: InvestorDividendRow[];
+  splits: InvestorSplitRow[];
+  calendar?: InvestorCalendar;
+  metrics?: { dividendRate?: number; dividendYield?: number };
+  warnings: string[];
+};

--- a/src/lib/investors/yahoo-finance.ts
+++ b/src/lib/investors/yahoo-finance.ts
@@ -1,0 +1,209 @@
+import type {
+  InvestorCalendar,
+  InvestorDividendRow,
+  InvestorQuote,
+  InvestorSplitRow,
+  InvestorTickerResponse,
+} from "./types";
+
+const YAHUA =
+  "Mozilla/5.0 (compatible; KnowledgeHub/1.0; +https://corporate-action.vercel.app)";
+
+async function fetchJson<T>(url: string): Promise<T> {
+  const res = await fetch(url, {
+    headers: { "User-Agent": YAHUA, Accept: "application/json" },
+    next: { revalidate: 0 },
+  });
+  if (!res.ok) {
+    throw new Error(`Upstream ${res.status}`);
+  }
+  return res.json() as Promise<T>;
+}
+
+type ChartResult = {
+  chart?: {
+    result?: Array<{
+      meta?: {
+        symbol?: string;
+        regularMarketPrice?: number;
+        chartPreviousClose?: number;
+        longName?: string;
+        shortName?: string;
+        exchangeName?: string;
+        quoteType?: string;
+      };
+      events?: {
+        dividends?: Record<string, { amount?: number; date?: number }>;
+        splits?: Record<
+          string,
+          { date?: number; numerator?: number; denominator?: number }
+        >;
+      };
+    }>;
+    error?: { description?: string };
+  };
+};
+
+type QuoteSummaryResult = {
+  quoteSummary?: {
+    result?: Array<{
+      summaryProfile?: { sector?: string };
+      price?: {
+        regularMarketPrice?: { raw?: number };
+        regularMarketChangePercent?: { raw?: number };
+      };
+      summaryDetail?: {
+        dividendRate?: { raw?: number };
+        dividendYield?: { raw?: number };
+        exDividendDate?: { raw?: number };
+      };
+      calendarEvents?: {
+        exDividendDate?: { raw?: number };
+        earnings?: {
+          earningsDate?: Array<{ raw?: number }>;
+        };
+      };
+    }>;
+    error?: { description?: string };
+  };
+};
+
+function isoDay(tsSec?: number): string | undefined {
+  if (tsSec == null || !Number.isFinite(tsSec)) return undefined;
+  return new Date(tsSec * 1000).toISOString().slice(0, 10);
+}
+
+function ratioFromSplit(n?: number, d?: number): string {
+  if (n == null || d == null || d === 0) return "—";
+  return `${n}:${d}`;
+}
+
+/** Normalize user input to Yahoo symbol (e.g. brk.b → BRK-B). */
+export function normalizeTicker(raw: string): string {
+  return raw
+    .trim()
+    .toUpperCase()
+    .replace(/\s+/g, "")
+    .replace(/\./g, "-");
+}
+
+export async function buildInvestorPayload(
+  ticker: string,
+): Promise<InvestorTickerResponse> {
+  const warnings: string[] = [];
+  const sym = normalizeTicker(ticker);
+  if (!sym || !/^[A-Z0-9.\-]+$/.test(sym)) {
+    throw new Error("INVALID_TICKER");
+  }
+
+  const chartUrl = `https://query1.finance.yahoo.com/v8/finance/chart/${encodeURIComponent(sym)}?interval=1d&range=10y&events=div%7Csplit`;
+  const summaryUrl = `https://query1.finance.yahoo.com/v10/finance/quoteSummary/${encodeURIComponent(sym)}?modules=summaryProfile,price,summaryDetail,calendarEvents`;
+
+  const [chartJson, summaryJson] = await Promise.all([
+    fetchJson<ChartResult>(chartUrl),
+    fetchJson<QuoteSummaryResult>(summaryUrl).catch(() => null),
+  ]);
+
+  const err = chartJson.chart?.error?.description;
+  if (err) {
+    throw new Error("NOT_FOUND");
+  }
+
+  const result = chartJson.chart?.result?.[0];
+  if (!result?.meta) {
+    throw new Error("NOT_FOUND");
+  }
+
+  const meta = result.meta;
+  const price = meta.regularMarketPrice;
+  const prev = meta.chartPreviousClose;
+  let changePct: number | undefined;
+  if (
+    price != null &&
+    prev != null &&
+    prev !== 0 &&
+    Number.isFinite(price) &&
+    Number.isFinite(prev)
+  ) {
+    changePct = ((price - prev) / prev) * 100;
+  }
+
+  const quote: InvestorQuote = {
+    name: meta.longName ?? meta.shortName,
+    price,
+    changePct,
+    exchange: meta.exchangeName,
+  };
+
+  const divMap = result.events?.dividends ?? {};
+  const dividends: InvestorDividendRow[] = Object.entries(divMap)
+    .map(([ts, v]) => ({
+      date: isoDay(Number(ts)) ?? isoDay(v.date),
+      amount: v.amount ?? 0,
+    }))
+    .filter((r) => r.date)
+    .sort((a, b) => b.date!.localeCompare(a.date!))
+    .slice(0, 5)
+    .map((r) => ({ date: r.date!, amount: r.amount }));
+
+  const splitMap = result.events?.splits ?? {};
+  const splits: InvestorSplitRow[] = Object.entries(splitMap)
+    .map(([ts, v]) => ({
+      date: isoDay(Number(ts)) ?? isoDay(v.date),
+      ratio: ratioFromSplit(v.numerator, v.denominator),
+    }))
+    .filter((r) => r.date)
+    .sort((a, b) => b.date!.localeCompare(a.date!))
+    .slice(0, 8)
+    .map((r) => ({ date: r.date!, ratio: r.ratio }));
+
+  if (dividends.length === 0) {
+    warnings.push("No dividend history in chart range (or none paid).");
+  }
+
+  let calendar: InvestorCalendar | undefined;
+  let metrics: InvestorTickerResponse["metrics"];
+  let sector: string | undefined;
+
+  const qr = summaryJson?.quoteSummary?.result?.[0];
+  if (qr) {
+    sector = qr.summaryProfile?.sector;
+    const p = qr.price;
+    if (p?.regularMarketPrice?.raw != null) {
+      quote.price = p.regularMarketPrice.raw;
+    }
+    if (p?.regularMarketChangePercent?.raw != null) {
+      quote.changePct = p.regularMarketChangePercent.raw;
+    }
+    const exRaw =
+      qr.calendarEvents?.exDividendDate?.raw ??
+      qr.summaryDetail?.exDividendDate?.raw;
+    const earnRaw = qr.calendarEvents?.earnings?.earningsDate?.[0]?.raw;
+
+    calendar = {
+      exDividendDate: exRaw != null ? isoDay(exRaw) : undefined,
+      earningsDate: earnRaw != null ? isoDay(earnRaw) : undefined,
+    };
+
+    const dr = qr.summaryDetail?.dividendRate?.raw;
+    const dy = qr.summaryDetail?.dividendYield?.raw;
+    metrics = {};
+    if (dr != null) metrics.dividendRate = dr;
+    if (dy != null) metrics.dividendYield = dy * 100;
+  } else {
+    warnings.push("Quote summary unavailable; calendar and some metrics may be missing.");
+  }
+
+  if (sector) quote.sector = sector;
+
+  return {
+    ticker: meta.symbol ?? sym,
+    fetchedAt: new Date().toISOString(),
+    quote,
+    dividends,
+    splits,
+    calendar,
+    metrics,
+    warnings,
+  };
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the **Investor Intelligence Browser** from `SPECS/inbox/feature-investor-intelligence-browser.md` and the draft PRD in `SPECS/outbox/investor-intelligence-browser-prd.md`, using a **Vercel-safe** data path: `GET /api/investors/quote?ticker=` aggregates **Yahoo Finance** public JSON (no Python / no subprocess). **5-minute TTL** in-memory cache per normalized ticker on the server.

## User-visible

- New **`/investors/`** page: search, example tickers, quote strip, last-5 dividends + trend label, splits list, upcoming ex-div / earnings with day countdown when dates exist, disclaimer.
- **Home** quick links: fourth tile → Investor snapshot.
- **README**: live pages table includes `/investors/`.

## Technical

- `src/lib/investors/yahoo-finance.ts` — chart + quoteSummary fetch, DTO mapping.
- `src/app/api/investors/quote/route.ts` — `dynamic = "force-dynamic"`, cache map.
- Reuses existing **`GlossaryTerm`** (Tippy) for jargon on the investor cards.

## Risks / follow-ups

- Yahoo endpoints are **unofficial**; rate limits or schema changes could break production — monitor and consider a paid provider if needed.
- **Not** full `yfinance` parity; PRD Option C-style “HTTP-only” path.

## Verification

- `npm run lint`, `npx tsc --noEmit`, `npm run build`
- After deploy: open `/investors/`, search `AAPL`; confirm `/api/investors/quote/?ticker=AAPL` returns JSON.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a2ae96ad-0263-4d06-8c3c-4b25301fddcf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a2ae96ad-0263-4d06-8c3c-4b25301fddcf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

