### PR TITLE
feat: voluntary event taxonomy — secondary offering and private placement

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -105,7 +105,7 @@ const TREE_STEPS = [
     hint: "Mandatory = company triggers automatically. Voluntary = shareholder action required.",
     options: [
       { label: "Mandatory", sub: "Dividend, split, merger, spin-off, bonus, return of capital", color: "bg-green-500/10 border-green-500/30 text-green-400" },
-      { label: "Voluntary", sub: "Rights, tender offer, secondary offering, partial tender", color: "bg-orange-500/10 border-orange-500/30 text-orange-400" },
+      { label: "Voluntary", sub: "Rights, tender, secondary offering, private placement", color: "bg-orange-500/10 border-orange-500/30 text-orange-400" },
     ],
   },
   {

--- a/src/components/projection-gap-simulator.tsx
+++ b/src/components/projection-gap-simulator.tsx
@@ -50,6 +50,7 @@ const defaultMetrics = (): SimulatorInput["metrics"] => ({
   freeFloatChangePp: "",
   tenderAcceptancePct: "",
   rightsDiscountPct: "",
+  offeringSizePctOfMc: "",
 });
 
 const defaultInput = (): SimulatorInput => ({
@@ -329,7 +330,7 @@ export function ProjectionGapSimulator() {
                       >
                         <span className="text-base font-semibold text-foreground">Voluntary</span>
                         <span className="mt-2 block text-pretty text-sm leading-relaxed text-muted-foreground">
-                          Rights issues, tenders, buybacks — outcomes depend on shareholder participation.
+                          Rights, tenders, secondary offerings, private placements — outcomes depend on participation or allocation.
                         </span>
                       </button>
                     </div>
@@ -601,6 +602,14 @@ export function ProjectionGapSimulator() {
                       <p className="text-sm font-medium text-foreground">Optional numbers</p>
                       <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
                         Rough percentages are fine. Leave blank if unknown — the simulator will ignore that signal.
+                        {(input.eventFamily === "secondary_offering" ||
+                          input.eventFamily === "private_placement") && (
+                          <>
+                            {" "}
+                            For secondary offerings and private placements, issue size as % of market cap sharpens
+                            materiality hints (~5% split).
+                          </>
+                        )}
                       </p>
                       <div className="mt-4 grid grid-cols-1 gap-4 md:grid-cols-2">
                         <label className="block space-y-1.5">
@@ -675,6 +684,27 @@ export function ProjectionGapSimulator() {
                             className="w-full rounded-xl border border-border bg-background px-3 py-2.5 text-sm outline-none focus-visible:border-primary/50 focus-visible:shadow-[0_0_0_3px_oklch(0.72_0.19_250/0.25)]"
                           />
                         </label>
+                        {(input.eventFamily === "secondary_offering" ||
+                          input.eventFamily === "private_placement") && (
+                          <label className="block space-y-1.5 md:col-span-2">
+                            <span className="text-xs font-medium text-muted-foreground">
+                              Issue size vs market cap (%)
+                            </span>
+                            <input
+                              type="text"
+                              inputMode="decimal"
+                              placeholder="e.g. 3 or 8"
+                              value={input.metrics.offeringSizePctOfMc}
+                              onChange={(e) =>
+                                setInput((p) => ({
+                                  ...p,
+                                  metrics: { ...p.metrics, offeringSizePctOfMc: e.target.value },
+                                }))
+                              }
+                              className="w-full rounded-xl border border-border bg-background px-3 py-2.5 text-sm outline-none focus-visible:border-primary/50 focus-visible:shadow-[0_0_0_3px_oklch(0.72_0.19_250/0.25)]"
+                            />
+                          </label>
+                        )}
                       </div>
                     </div>
                   </div>

--- a/src/lib/simulator/simulator-engine.ts
+++ b/src/lib/simulator/simulator-engine.ts
@@ -9,7 +9,7 @@ import type {
   SimulatorResult,
 } from "@/lib/simulator/types";
 
-const RULES_VERSION = "1.1.0";
+const RULES_VERSION = "1.2.0";
 
 const DISCLAIMER =
   "This simulator produces possible explanations only. It does not replace official vendor methodology, notices, or your internal policy. Always confirm with vendor documentation and primary sources.";
@@ -106,6 +106,7 @@ export function runSimulator(input: SimulatorInput): SimulatorResult {
   const ffDelta = parseOptionalPct(input.metrics.freeFloatChangePp);
   const tenderPct = parseOptionalPct(input.metrics.tenderAcceptancePct);
   const rightsDisc = parseOptionalPct(input.metrics.rightsDiscountPct);
+  const offeringSizePct = parseOptionalPct(input.metrics.offeringSizePctOfMc);
 
   const dup = overlap(input.missingVendors, input.presentVendors);
   if (dup.length > 0) {
@@ -158,7 +159,7 @@ export function runSimulator(input: SimulatorInput): SimulatorResult {
       id: "voluntary-uncertainty",
       title: "VOLUNTARY EVENT — PARTICIPATION OPEN",
       explanation:
-        "Rights issues, tenders, and similar voluntary actions often need confirmed subscription or acceptance before every vendor adjusts floats or share counts. One feed may show an early or provisional line while another waits for final results — especially where free-float or materiality thresholds differ.",
+        "Rights issues, tenders, secondary offerings, private placements, and similar voluntary actions often need confirmed subscription, acceptance, or allocation before every vendor adjusts floats or share counts. One feed may show an early or provisional line while another waits for final results — especially where free-float or materiality thresholds differ.",
       relevance: "high",
       appliesToVendors: onlyMissing,
     });
@@ -222,6 +223,64 @@ export function runSimulator(input: SimulatorInput): SimulatorResult {
       relevance: "low",
       appliesToVendors: onlyMissing,
     });
+  }
+
+  if (input.eventFamily === "secondary_offering") {
+    if (offeringSizePct !== null && offeringSizePct >= 5) {
+      hypotheses.push({
+        id: "secondary-offering-large",
+        title: "LARGE SECONDARY OFFERING",
+        explanation: `You indicated the new issue is on the order of ${offeringSizePct}% of market cap (roughly the “~5%” stress band many desks use). At that scale, float and share-count narratives skew toward immediate or near-term adjustment in several methodologies, while others may still wait for settlement, exchange notice, or confirmed allocation — producing the gap you are seeing.`,
+        relevance: "high",
+        appliesToVendors: onlyMissing,
+      });
+    } else if (offeringSizePct !== null && offeringSizePct < 5) {
+      hypotheses.push({
+        id: "secondary-offering-below-threshold",
+        title: "SECONDARY OFFERING BELOW SIZE STRESS BAND",
+        explanation: `Around ${offeringSizePct}% of market cap sits below the common ~5% “large deal” heuristic. Smaller issues are more often treated as below immediate materiality: some vendors defer to the next quarterly index review (QIR) language while another feed already carries a placeholder or early line.`,
+        relevance: "medium",
+        appliesToVendors: onlyMissing,
+      });
+    } else {
+      hypotheses.push({
+        id: "secondary-offering-materiality",
+        title: "SECONDARY OFFERING — SIZE AND FLOAT",
+        explanation:
+          "Secondary offerings are materiality- and free-float sensitive. Vendors disagree on when share count updates versus when lines first appear in open-constituent files. Add a rough % of market cap under optional numbers if you can — the simulator uses ~5% as a simple split between “more immediate adjustment” vs “more QIR / deferred” framing.",
+        relevance: "medium",
+        appliesToVendors: onlyMissing,
+      });
+    }
+  }
+
+  if (input.eventFamily === "private_placement") {
+    if (offeringSizePct !== null && offeringSizePct >= 5) {
+      hypotheses.push({
+        id: "private-placement-material",
+        title: "MATERIAL PRIVATE PLACEMENT",
+        explanation: `You indicated roughly ${offeringSizePct}% of market cap. Above the common ~5% materiality heuristic, several vendors lean toward immediate adjustment or urgent divisor-related updates once terms are confirmed; others may still lag on feed publication — not because they disagree on economics, but because of confirmation gates.`,
+        relevance: "high",
+        appliesToVendors: onlyMissing,
+      });
+    } else if (offeringSizePct !== null && offeringSizePct < 5) {
+      hypotheses.push({
+        id: "private-placement-below-material",
+        title: "PRIVATE PLACEMENT — BELOW MATERIALITY HEURISTIC",
+        explanation: `Around ${offeringSizePct}% of market cap is below the ~5% band used here as a simple materiality split. Below-threshold placements are often aligned with deferred-to-QIR narratives on some indices while another vendor already reflects a provisional line — match this to Step 4 style materiality questions in your own process.`,
+        relevance: "medium",
+        appliesToVendors: onlyMissing,
+      });
+    } else {
+      hypotheses.push({
+        id: "private-placement-materiality-unknown",
+        title: "PRIVATE PLACEMENT — MATERIALITY GATE",
+        explanation:
+          "Private placements usually turn on whether the issue crosses each vendor’s materiality threshold relative to float and index rules. Without a rough issue size, treat divergence as timing and confirmation: one feed may wait for regulatory or exchange finality while another publishes earlier. Add % of market cap under optional numbers for a sharper split.",
+        relevance: "medium",
+        appliesToVendors: onlyMissing,
+      });
+    }
   }
 
   if (input.eventFamily === "merger") {
@@ -372,13 +431,16 @@ export function runSimulator(input: SimulatorInput): SimulatorResult {
     "merger",
     "spinoff",
     "rights",
+    "tender",
+    "secondary_offering",
+    "private_placement",
   ];
   if (!pilotFamilies.includes(input.eventFamily)) {
     hypotheses.push({
       id: "pilot-stub",
       title: "Broader reference may be needed",
       explanation:
-        "The richest rule set here focuses on dividends, splits, M&A, spin-offs, and rights. For this event type, lean on the vendor reference for thresholds and timing, and treat simulator output as a starting point.",
+        "The richest rule set here focuses on dividends, splits, M&A, spin-offs, rights, tenders, secondary offerings, and private placements. For this event type, lean on the vendor reference for thresholds and timing, and treat simulator output as a starting point.",
       relevance: "low",
       appliesToVendors: onlyMissing,
     });

--- a/src/lib/simulator/taxonomy.ts
+++ b/src/lib/simulator/taxonomy.ts
@@ -10,6 +10,8 @@ export const FAMILY_TO_CLASS: Record<EventFamily, EventClass> = {
   delisting: "mandatory",
   rights: "voluntary",
   tender: "voluntary",
+  secondary_offering: "voluntary",
+  private_placement: "voluntary",
   other: "mandatory",
 };
 
@@ -23,7 +25,12 @@ export const MANDATORY_FAMILIES: EventFamily[] = [
   "other",
 ];
 
-export const VOLUNTARY_FAMILIES: EventFamily[] = ["rights", "tender"];
+export const VOLUNTARY_FAMILIES: EventFamily[] = [
+  "rights",
+  "tender",
+  "secondary_offering",
+  "private_placement",
+];
 
 export function getEventClassFromFamily(family: EventFamily): EventClass {
   return FAMILY_TO_CLASS[family] ?? "mandatory";
@@ -41,6 +48,8 @@ export function humanFamily(f: EventFamily): string {
     spinoff: "Spin-off",
     rights: "Rights issue",
     tender: "Tender or buyback",
+    secondary_offering: "Secondary offering",
+    private_placement: "Private placement",
     return_of_capital: "Return of capital",
     delisting: "Delisting",
     other: "Other corporate action",

--- a/src/lib/simulator/types.ts
+++ b/src/lib/simulator/types.ts
@@ -9,6 +9,8 @@ export type EventFamily =
   | "spinoff"
   | "rights"
   | "tender"
+  | "secondary_offering"
+  | "private_placement"
   | "return_of_capital"
   | "delisting"
   | "other";
@@ -36,6 +38,8 @@ export type SimulatorMetrics = {
   freeFloatChangePp: string;
   tenderAcceptancePct: string;
   rightsDiscountPct: string;
+  /** Rough % of market cap for secondary offerings / private placements — drives materiality heuristics. */
+  offeringSizePctOfMc: string;
 };
 
 export type SimulatorInput = {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the voluntary event taxonomy expansion from the voluntary-event PRD: adds **secondary offering** and **private placement** as voluntary families, keeps the simulator Step 2 list driven by `VOLUNTARY_FAMILIES`, and adds dedicated hypothesis branches (with optional issue-size % of market cap for a ~5% materiality split).

## Changes

- **Types:** `EventFamily` includes `secondary_offering` and `private_placement`; `SimulatorMetrics` adds `offeringSizePctOfMc` for the materiality heuristic.
- **Taxonomy:** `FAMILY_TO_CLASS`, `VOLUNTARY_FAMILIES` (order: rights, tender, secondary offering, private placement), and `humanFamily()` labels.
- **Engine:** Distinct hypotheses for both new families; voluntary umbrella copy updated; `pilotFamilies` includes tender, secondary offering, and private placement (tender no longer relies only on the generic stub); rules version **1.2.0**.
- **UI:** Voluntary category description aligned with four families; optional numbers section explains issue size for those families and shows an **Issue size vs market cap (%)** field when relevant.
- **Homepage:** Decision tree Voluntary sub-label lists the same four surfaces as the simulator.

## Verification

- `npm run lint`
- `npx tsc --noEmit`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9b840c84-aa04-4871-8775-b53ec7fe6a36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9b840c84-aa04-4871-8775-b53ec7fe6a36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

