### PR TITLE
feat: Investor snapshot Yahoo data path hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@ GitHub Actions on `main` runs lint, typecheck, and `npm run build` (see `.github
 
 **Agent handoff (Goop / OpenClaw):** `SPECS/HANDOFF-OPENCLAW-GOOP-VERCEL.md`
 
+### Investor snapshot data
+
+The `/investors/` page and `GET /api/investors/quote?ticker=SYMBOL` load delayed market data from **Yahoo Finance** over HTTPS (chart `v8/finance/chart` for dividends, splits, and meta price; `v10/finance/quoteSummary` for sector, dividend rate/yield, and calendar hints). There is no Python or subprocess on Vercel. See `SPECS/approved/prd-investor-snapshot-data-source.md` for the API contract (`InvestorTickerResponse` in `src/lib/investors/types.ts`).
+
 ## Live Pages
 
 | Page | URL (on production host) |

--- a/src/app/api/investors/quote/route.ts
+++ b/src/app/api/investors/quote/route.ts
@@ -2,10 +2,18 @@ import { NextResponse } from "next/server";
 
 import { buildInvestorPayload, normalizeTicker } from "@/lib/investors/yahoo-finance";
 
-export const dynamic = "force-dynamic";
+/** CDN + browser hint; origin still dedupes with in-process TTL below. */
+const SUCCESS_CACHE_CONTROL =
+  "public, s-maxage=300, stale-while-revalidate=600";
 
 const TTL_MS = 5 * 60 * 1000;
 const cache = new Map<string, { at: number; body: unknown }>();
+
+function jsonOk(body: unknown) {
+  return NextResponse.json(body, {
+    headers: { "Cache-Control": SUCCESS_CACHE_CONTROL },
+  });
+}
 
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
@@ -22,13 +30,13 @@ export async function GET(request: Request) {
   const now = Date.now();
   const hit = cache.get(key);
   if (hit && now - hit.at < TTL_MS) {
-    return NextResponse.json(hit.body);
+    return jsonOk(hit.body);
   }
 
   try {
     const body = await buildInvestorPayload(raw);
     cache.set(key, { at: now, body });
-    return NextResponse.json(body);
+    return jsonOk(body);
   } catch (e) {
     const msg = e instanceof Error ? e.message : "UNKNOWN";
     if (msg === "INVALID_TICKER") {

--- a/src/app/investors/page.tsx
+++ b/src/app/investors/page.tsx
@@ -11,6 +11,7 @@ import { InvestorQuoteStrip } from "@/components/investors/investor-quote-strip"
 import { DividendSummaryCard } from "@/components/investors/dividend-summary-card";
 import { SplitHistoryCard } from "@/components/investors/split-history-card";
 import { UpcomingEventsCard } from "@/components/investors/upcoming-events-card";
+import { InvestorDataWarnings } from "@/components/investors/investor-data-warnings";
 import type { InvestorTickerResponse } from "@/lib/investors/types";
 
 export default function InvestorsPage() {
@@ -116,6 +117,9 @@ export default function InvestorsPage() {
               quote={data?.quote}
               loading={loading}
             />
+            {data && data.warnings.length > 0 && (
+              <InvestorDataWarnings key={data.ticker} warnings={data.warnings} />
+            )}
             <div className="grid gap-6 md:grid-cols-1">
               <DividendSummaryCard
                 dividends={data?.dividends ?? []}
@@ -128,13 +132,6 @@ export default function InvestorsPage() {
                 <UpcomingEventsCard calendar={data?.calendar} loading={loading} />
               </div>
             </div>
-            {data && data.warnings.length > 0 && (
-              <ul className="text-xs text-muted-foreground">
-                {data.warnings.map((w) => (
-                  <li key={w}>· {w}</li>
-                ))}
-              </ul>
-            )}
           </motion.div>
         )}
 

--- a/src/components/investors/investor-data-warnings.tsx
+++ b/src/components/investors/investor-data-warnings.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { useState } from "react";
+import { AlertTriangleIcon, XIcon } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+
+interface Props {
+  warnings: string[];
+}
+
+export function InvestorDataWarnings({ warnings }: Props) {
+  const [dismissed, setDismissed] = useState(false);
+
+  if (warnings.length === 0 || dismissed) return null;
+
+  return (
+    <div
+      role="status"
+      className="rounded-xl border border-primary/25 bg-primary/5 px-4 py-3 text-sm text-foreground"
+    >
+      <div className="flex gap-3">
+        <AlertTriangleIcon
+          className="mt-0.5 size-4 shrink-0 text-primary"
+          aria-hidden
+        />
+        <div className="min-w-0 flex-1 space-y-2">
+          <p className="font-medium text-foreground">Data notes</p>
+          <ul className="list-inside list-disc space-y-1 text-muted-foreground">
+            {warnings.map((w) => (
+              <li key={w} className="pl-0.5">
+                {w}
+              </li>
+            ))}
+          </ul>
+        </div>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-xs"
+          className="shrink-0 text-muted-foreground hover:text-foreground"
+          onClick={() => setDismissed(true)}
+          aria-label="Dismiss data notes"
+        >
+          <XIcon className="size-4" aria-hidden />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/investors/types.ts
+++ b/src/lib/investors/types.ts
@@ -24,6 +24,7 @@ export type InvestorTickerResponse = {
   dividends: InvestorDividendRow[];
   splits: InvestorSplitRow[];
   calendar?: InvestorCalendar;
+  /** `dividendYield` is a percentage for display (e.g. 2.5 means 2.5%), from Yahoo raw × 100. */
   metrics?: { dividendRate?: number; dividendYield?: number };
   warnings: string[];
 };

--- a/src/lib/investors/yahoo-finance.ts
+++ b/src/lib/investors/yahoo-finance.ts
@@ -9,11 +9,23 @@ import type {
 const YAHUA =
   "Mozilla/5.0 (compatible; KnowledgeHub/1.0; +https://corporate-action.vercel.app)";
 
+const UPSTREAM_REVALIDATE_SEC = 300;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
 async function fetchJson<T>(url: string): Promise<T> {
-  const res = await fetch(url, {
+  const opts = {
     headers: { "User-Agent": YAHUA, Accept: "application/json" },
-    next: { revalidate: 0 },
-  });
+    next: { revalidate: UPSTREAM_REVALIDATE_SEC },
+  } as const;
+
+  let res = await fetch(url, opts);
+  if (!res.ok && (res.status === 429 || res.status >= 500)) {
+    await sleep(400);
+    res = await fetch(url, opts);
+  }
   if (!res.ok) {
     throw new Error(`Upstream ${res.status}`);
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the approved investor snapshot data-source hardening from `SPECS/approved/prd-investor-snapshot-data-source.md`: CDN-friendly caching on successful `GET /api/investors/quote` responses, five-minute upstream `fetch` revalidation aligned with the in-memory TTL, one retry with backoff on transient Yahoo failures (429/5xx), README documentation of the Yahoo chart + quoteSummary flow, and a dismissible **Data notes** banner for non-empty `warnings` (remounted per ticker via `key`).

## Verification

- `npm run lint`
- `npx tsc --noEmit`

## Notes

- Removed `force-dynamic` from the quote route so Next can respect caching hints where applicable; in-process Map TTL remains for warm isolates.
- `dividendYield` on `InvestorTickerResponse` is documented as display percent (Yahoo raw × 100); UI already formats with `%`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f70e58c0-88d7-486d-9a5e-c4bf2d404209"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f70e58c0-88d7-486d-9a5e-c4bf2d404209"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

