### PR TITLE
feat: Base UI glossary tooltips for investor intelligence

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ GitHub Actions on `main` runs lint, typecheck, and `npm run build` (see `.github
 
 **Agent handoff (Goop / OpenClaw):** `SPECS/HANDOFF-OPENCLAW-GOOP-VERCEL.md`
 
+**Investor snapshot (production):** The `/investors/` page calls the Next.js route handler `GET /api/investors/quote`, which fetches Yahoo Finance JSON server-side (chart `v8` with dividend/split events, plus `v10` quote summary for sector, dividend metrics, and calendar hints). No API key. Responses are cached in memory for five minutes per normalized ticker inside that handler (per serverless instance).
+
 ## Live Pages
 
 | Page | URL (on production host) |

--- a/src/components/ui/glossary-term.tsx
+++ b/src/components/ui/glossary-term.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import Tippy from "@tippyjs/react";
-import "tippy.js/dist/tippy.css";
+import { Tooltip } from "@base-ui/react/tooltip";
 
 interface Props {
   term: string;
@@ -11,22 +10,25 @@ interface Props {
 
 export function GlossaryTerm({ term, definition, children }: Props) {
   return (
-    <Tippy
-      content={
-        <div className="max-w-[220px]">
-          <p className="mb-1 text-[13px] font-semibold leading-tight text-white">
-            {term}
-          </p>
-          <p className="text-[12px] leading-relaxed text-white/80">{definition}</p>
-        </div>
-      }
-      placement="top"
-      duration={200}
-      delay={[200, 0]}
-    >
-      <span className="cursor-help border-b border-dotted border-muted-foreground/50">
+    <Tooltip.Root>
+      <Tooltip.Trigger
+        type="button"
+        delay={180}
+        closeDelay={80}
+        className="inline cursor-help border-0 border-b border-dotted border-muted-foreground/60 bg-transparent p-0 text-left font-[inherit] text-[inherit] leading-[inherit] underline-offset-2 hover:border-primary/60 focus-visible:rounded-sm focus-visible:border-transparent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      >
         {children}
-      </span>
-    </Tippy>
+      </Tooltip.Trigger>
+      <Tooltip.Portal>
+        <Tooltip.Positioner side="top" sideOffset={8} className="z-50">
+          <Tooltip.Popup className="max-w-[min(280px,calc(100vw-1.5rem))] rounded-xl border border-border bg-popover px-3 py-2 text-popover-foreground shadow-lg outline-none">
+            <p className="mb-1 text-[13px] font-semibold leading-tight">{term}</p>
+            <p className="text-[12px] leading-relaxed text-muted-foreground">
+              {definition}
+            </p>
+          </Tooltip.Popup>
+        </Tooltip.Positioner>
+      </Tooltip.Portal>
+    </Tooltip.Root>
   );
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The approved **Investor Intelligence Browser** work was largely already on `main` (`/investors/`, `GET /api/investors/quote`, Yahoo chart + quoteSummary, 5-minute in-route cache, cards, home quick link).

This PR completes an outstanding PRD item: **replace Tippy in the shared `GlossaryTerm` component** with **Base UI (`@base-ui/react`) Tooltip** so investor glossary terms are keyboard-focusable and use semantic popover tokens (no hardcoded hex in tooltip chrome). The vendor page still uses Tippy for its large glossary surface.

## README

Adds a short paragraph documenting **production data flow** (Next route handler → Yahoo JSON, in-memory TTL per ticker) per acceptance criteria.

## Verification

- `npm run lint`
- `npx tsc --noEmit`
- `npm run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-be2ad946-9702-40c2-8bb6-8ca71a5104f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-be2ad946-9702-40c2-8bb6-8ca71a5104f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

