### PR TITLE
fix(simulator): align with canonical 13-type ISO CAEV taxonomy + per-vendor verdicts

### DIFF
--- a/src/components/projection-gap-simulator.tsx
+++ b/src/components/projection-gap-simulator.tsx
@@ -11,7 +11,15 @@ import { cn } from "@/lib/utils";
 import { VENDOR_IDS, vendorLabel, vendorAbbr, type VendorId } from "@/lib/vendors";
 import { runSimulator } from "@/lib/simulator/simulator-engine";
 import { familiesForClass, humanFamily } from "@/lib/simulator/taxonomy";
-import { eventNamesSentence, mandatoryEventCount, voluntaryEventCount } from "@/lib/event-taxonomy";
+import {
+  CANONICAL_EVENTS,
+  canonicalEventById,
+  eventNamesSentence,
+  mandatoryEventCount,
+  voluntaryEventCount,
+  type CanonicalEventId,
+  type EventCategory,
+} from "@/lib/event-taxonomy";
 import type { EventFamily, SimulatorInput, SimulatorResult } from "@/lib/simulator/types";
 
 const STEP_COUNT = 6;
@@ -33,6 +41,13 @@ const STEP_LABELS_SHORT = [
   "Vendors",
   "Results",
 ] as const;
+
+const CATEGORY_ORDER: EventCategory[] = [
+  "Equity Income",
+  "Corporate Structure",
+  "Equity Offerings",
+  "M&A",
+];
 
 function todayIso(): string {
   const d = new Date();
@@ -58,7 +73,6 @@ const defaultInput = (): SimulatorInput => ({
   mnaIndexParties: "both",
   spinoffChildEligible: "unknown",
   spinoffPhase: "unknown",
-  dividendFlavor: "unknown",
   indexReturnVariant: "unknown",
   metrics: defaultMetrics(),
   effectiveDate: "",
@@ -98,6 +112,17 @@ function coerceFamilyForCategory(
   return allowed[0] ?? current;
 }
 
+const FAMILIES_NEEDING_CONTEXT: Set<CanonicalEventId> = new Set([
+  "rights-issue",
+  "merger",
+  "tender-offer",
+  "spin-off",
+  "cash-dividend",
+  "special-dividend",
+  "secondary-offering",
+  "private-placement",
+]);
+
 export function ProjectionGapSimulator() {
   const [step, setStep] = useState(0);
   const [input, setInput] = useState<SimulatorInput>(defaultInput);
@@ -109,15 +134,21 @@ export function ProjectionGapSimulator() {
     [input.eventCategory],
   );
 
-  const canShowSubdetails = useMemo(() => {
-    const f = input.eventFamily;
-    return (
-      f === "rights" ||
-      f === "merger" ||
-      f === "spinoff" ||
-      f === "dividend"
-    );
-  }, [input.eventFamily]);
+  const groupedFamilies = useMemo(() => {
+    const set = new Set(allowedFamilies);
+    return CATEGORY_ORDER.map((cat) => ({
+      category: cat,
+      events: CANONICAL_EVENTS.filter((e) => e.category === cat && set.has(e.id)),
+    })).filter((g) => g.events.length > 0);
+  }, [allowedFamilies]);
+
+  const canShowSubdetails = useMemo(
+    () => FAMILIES_NEEDING_CONTEXT.has(input.eventFamily as CanonicalEventId),
+    [input.eventFamily],
+  );
+
+  const isDividendLike =
+    input.eventFamily === "cash-dividend" || input.eventFamily === "special-dividend";
 
   function validateStep(s: number): string | null {
     if (s === 3) {
@@ -256,7 +287,7 @@ export function ProjectionGapSimulator() {
         <div className="min-w-0 w-full max-w-full flex-1 basis-0">
           <div className="mb-6">
             <p className="text-sm leading-relaxed text-muted-foreground">
-              A calm walkthrough — tell us what you are seeing. We will suggest plausible reasons, not vendor rulings.
+              A calm walkthrough — tell us what you are seeing. The verdict and per-vendor reasoning are derived from the documented rules in the Vendor Reference.
             </p>
           </div>
 
@@ -276,7 +307,7 @@ export function ProjectionGapSimulator() {
                       What kind of situation is this?
                     </p>
                     <p className="text-sm leading-relaxed text-muted-foreground">
-                      This matches the Vendor Reference taxonomy ({mandatoryEventCount()} mandatory, {voluntaryEventCount()} voluntary). The next step only lists high-level families that fit the category you pick here.
+                      Same taxonomy as the Vendor Reference: {mandatoryEventCount()} mandatory and {voluntaryEventCount()} voluntary event types (13 in total). The next step lists the canonical types within the category you pick.
                     </p>
                     <div className="grid min-w-0 grid-cols-1 gap-3 md:grid-cols-2">
                       <button
@@ -298,7 +329,9 @@ export function ProjectionGapSimulator() {
                             : "border-border/80 bg-background/40 hover:border-primary/25 hover:bg-background/60",
                         )}
                       >
-                        <span className="text-base font-semibold text-foreground">Mandatory</span>
+                        <span className="text-base font-semibold text-foreground">
+                          Mandatory · {mandatoryEventCount()} types
+                        </span>
                         <span className="mt-2 block text-pretty text-sm leading-relaxed text-muted-foreground">
                           {eventNamesSentence("mandatory")} — confirmed corporate actions without shareholder opt-in.
                         </span>
@@ -322,7 +355,9 @@ export function ProjectionGapSimulator() {
                             : "border-border/80 bg-background/40 hover:border-primary/25 hover:bg-background/60",
                         )}
                       >
-                        <span className="text-base font-semibold text-foreground">Voluntary</span>
+                        <span className="text-base font-semibold text-foreground">
+                          Voluntary · {voluntaryEventCount()} types
+                        </span>
                         <span className="mt-2 block text-pretty text-sm leading-relaxed text-muted-foreground">
                           {eventNamesSentence("voluntary")} — treatment depends on participation, thresholds, or classification rules.
                         </span>
@@ -337,28 +372,38 @@ export function ProjectionGapSimulator() {
                       Which event is it?
                     </p>
                     <p className="text-sm text-muted-foreground">
-                      Showing simulator families grouped under{" "}
+                      Showing the {allowedFamilies.length} canonical{" "}
                       <span className="font-medium text-foreground">
                         {input.eventCategory === "mandatory" ? "mandatory" : "voluntary"}
                       </span>{" "}
-                      on the vendor reference. The selected family drives the hypotheses below.
+                      types from the Vendor Reference (ISO 20022 CAEV).
                     </p>
-                    {/* min-w-0: grid items default to min-width:auto and refuse to shrink — caused ~93px spill */}
-                    <div className="grid min-w-0 grid-cols-1 gap-2 sm:grid-cols-2">
-                      {allowedFamilies.map((value) => (
-                        <button
-                          key={value}
-                          type="button"
-                          onClick={() => setInput((p) => ({ ...p, eventFamily: value }))}
-                          className={cn(
-                            "min-w-0 max-w-full break-words rounded-2xl border px-4 py-3.5 text-left text-sm font-medium leading-snug transition-all",
-                            input.eventFamily === value
-                              ? "border-primary/45 bg-primary/12 text-foreground"
-                              : "border-border/70 bg-background/35 text-muted-foreground hover:border-primary/30 hover:text-foreground",
-                          )}
-                        >
-                          {familyLabel(value)}
-                        </button>
+                    <div className="space-y-5">
+                      {groupedFamilies.map((group) => (
+                        <fieldset key={group.category} className="space-y-2">
+                          <legend className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+                            {group.category}
+                          </legend>
+                          <div className="grid min-w-0 grid-cols-1 gap-2 sm:grid-cols-2">
+                            {group.events.map((evt) => (
+                              <button
+                                key={evt.id}
+                                type="button"
+                                onClick={() =>
+                                  setInput((p) => ({ ...p, eventFamily: evt.id as EventFamily }))
+                                }
+                                className={cn(
+                                  "min-w-0 max-w-full break-words rounded-2xl border px-4 py-3.5 text-left text-sm font-medium leading-snug transition-all",
+                                  input.eventFamily === evt.id
+                                    ? "border-primary/45 bg-primary/12 text-foreground"
+                                    : "border-border/70 bg-background/35 text-muted-foreground hover:border-primary/30 hover:text-foreground",
+                                )}
+                              >
+                                {familyLabel(evt.id as EventFamily)}
+                              </button>
+                            ))}
+                          </div>
+                        </fieldset>
                       ))}
                     </div>
                   </div>
@@ -369,17 +414,17 @@ export function ProjectionGapSimulator() {
                     <div>
                       <p className="text-base font-medium text-foreground">Event context</p>
                       <p className="mt-1 text-sm leading-relaxed text-muted-foreground">
-                        Optional detail helps narrow the story. Skip anything you do not know yet.
+                        Optional detail tightens the per-vendor verdict. Skip anything you do not know yet.
                       </p>
                     </div>
 
                     {!canShowSubdetails ? (
                       <p className="rounded-2xl border border-dashed border-border/80 bg-background/30 px-4 py-4 text-sm leading-relaxed text-muted-foreground">
-                        No extra prompts for this event type. Optional numbers below still apply if relevant (for example free-float change around a tender).
+                        No extra prompts for {humanFamily(input.eventFamily).toLowerCase()}. Optional numbers below still apply if relevant (for example free-float change around a tender).
                       </p>
                     ) : (
                       <div className="space-y-6">
-                        {input.eventFamily === "rights" && (
+                        {input.eventFamily === "rights-issue" && (
                           <fieldset className="space-y-3">
                             <legend className="text-sm font-medium text-foreground">Rights</legend>
                             <div className="flex flex-wrap gap-2">
@@ -419,34 +464,36 @@ export function ProjectionGapSimulator() {
                           </fieldset>
                         )}
 
-                        {input.eventFamily === "merger" && (
+                        {(input.eventFamily === "merger" || input.eventFamily === "tender-offer") && (
                           <div className="space-y-5">
-                            <fieldset className="space-y-3">
-                              <legend className="text-sm font-medium text-foreground">Deal</legend>
-                              <div className="flex flex-wrap gap-2">
-                                {(
-                                  [
-                                    ["stock", "Mostly stock"],
-                                    ["cash", "Mostly cash"],
-                                    ["mixed", "Mixed or unclear"],
-                                  ] as const
-                                ).map(([v, label]) => (
-                                  <button
-                                    key={v}
-                                    type="button"
-                                    onClick={() => setInput((p) => ({ ...p, mnaDealType: v }))}
-                                    className={cn(
-                                      "rounded-full border px-4 py-2 text-sm transition-all",
-                                      input.mnaDealType === v
-                                        ? "border-primary/50 bg-primary/15 text-foreground"
-                                        : "border-border bg-background/50 text-muted-foreground hover:text-foreground",
-                                    )}
-                                  >
-                                    {label}
-                                  </button>
-                                ))}
-                              </div>
-                            </fieldset>
+                            {input.eventFamily === "merger" && (
+                              <fieldset className="space-y-3">
+                                <legend className="text-sm font-medium text-foreground">Deal</legend>
+                                <div className="flex flex-wrap gap-2">
+                                  {(
+                                    [
+                                      ["stock", "Mostly stock"],
+                                      ["cash", "Mostly cash"],
+                                      ["mixed", "Mixed or unclear"],
+                                    ] as const
+                                  ).map(([v, label]) => (
+                                    <button
+                                      key={v}
+                                      type="button"
+                                      onClick={() => setInput((p) => ({ ...p, mnaDealType: v }))}
+                                      className={cn(
+                                        "rounded-full border px-4 py-2 text-sm transition-all",
+                                        input.mnaDealType === v
+                                          ? "border-primary/50 bg-primary/15 text-foreground"
+                                          : "border-border bg-background/50 text-muted-foreground hover:text-foreground",
+                                      )}
+                                    >
+                                      {label}
+                                    </button>
+                                  ))}
+                                </div>
+                              </fieldset>
+                            )}
                             <fieldset className="space-y-3">
                               <legend className="text-sm font-medium text-foreground">Index membership</legend>
                               <div className="flex flex-wrap gap-2">
@@ -476,7 +523,7 @@ export function ProjectionGapSimulator() {
                           </div>
                         )}
 
-                        {input.eventFamily === "spinoff" && (
+                        {input.eventFamily === "spin-off" && (
                           <div className="space-y-5">
                             <fieldset className="space-y-3">
                               <legend className="text-sm font-medium text-foreground">Spin-off child</legend>
@@ -535,62 +582,36 @@ export function ProjectionGapSimulator() {
                           </div>
                         )}
 
-                        {input.eventFamily === "dividend" && (
-                          <div className="space-y-5">
-                            <fieldset className="space-y-3">
-                              <legend className="text-sm font-medium text-foreground">Dividend</legend>
-                              <div className="flex flex-wrap gap-2">
-                                {(
-                                  [
-                                    ["ordinary", "Ordinary"],
-                                    ["special", "Special"],
-                                    ["unknown", "Unknown"],
-                                  ] as const
-                                ).map(([v, label]) => (
-                                  <button
-                                    key={v}
-                                    type="button"
-                                    onClick={() => setInput((p) => ({ ...p, dividendFlavor: v }))}
-                                    className={cn(
-                                      "rounded-full border px-4 py-2 text-sm transition-all",
-                                      input.dividendFlavor === v
-                                        ? "border-primary/50 bg-primary/15 text-foreground"
-                                        : "border-border bg-background/50 text-muted-foreground hover:text-foreground",
-                                    )}
-                                  >
-                                    {label}
-                                  </button>
-                                ))}
-                              </div>
-                            </fieldset>
-                            <fieldset className="space-y-3">
-                              <legend className="text-sm font-medium text-foreground">Index variant you are comparing</legend>
-                              <div className="flex flex-wrap gap-2">
-                                {(
-                                  [
-                                    ["pr", "PR"],
-                                    ["tr", "TR"],
-                                    ["ntr", "NTR"],
-                                    ["unknown", "Not applicable"],
-                                  ] as const
-                                ).map(([v, label]) => (
-                                  <button
-                                    key={v}
-                                    type="button"
-                                    onClick={() => setInput((p) => ({ ...p, indexReturnVariant: v }))}
-                                    className={cn(
-                                      "rounded-full border px-4 py-2 text-sm transition-all",
-                                      input.indexReturnVariant === v
-                                        ? "border-primary/50 bg-primary/15 text-foreground"
-                                        : "border-border bg-background/50 text-muted-foreground hover:text-foreground",
-                                    )}
-                                  >
-                                    {label}
-                                  </button>
-                                ))}
-                              </div>
-                            </fieldset>
-                          </div>
+                        {isDividendLike && (
+                          <fieldset className="space-y-3">
+                            <legend className="text-sm font-medium text-foreground">
+                              Index variant you are comparing
+                            </legend>
+                            <div className="flex flex-wrap gap-2">
+                              {(
+                                [
+                                  ["pr", "PR"],
+                                  ["tr", "TR"],
+                                  ["ntr", "NTR"],
+                                  ["unknown", "Not applicable"],
+                                ] as const
+                              ).map(([v, label]) => (
+                                <button
+                                  key={v}
+                                  type="button"
+                                  onClick={() => setInput((p) => ({ ...p, indexReturnVariant: v }))}
+                                  className={cn(
+                                    "rounded-full border px-4 py-2 text-sm transition-all",
+                                    input.indexReturnVariant === v
+                                      ? "border-primary/50 bg-primary/15 text-foreground"
+                                      : "border-border bg-background/50 text-muted-foreground hover:text-foreground",
+                                  )}
+                                >
+                                  {label}
+                                </button>
+                              ))}
+                            </div>
+                          </fieldset>
                         )}
                       </div>
                     )}
@@ -598,7 +619,7 @@ export function ProjectionGapSimulator() {
                     <div className="rounded-3xl border border-border/60 bg-background/25 p-5 sm:p-6">
                       <p className="text-sm font-medium text-foreground">Optional numbers</p>
                       <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
-                        Rough percentages are fine. Leave blank if unknown — the simulator will ignore that signal.
+                        Rough percentages are fine. Leave blank if unknown — the simulator will say it cannot make the call rather than guess.
                       </p>
                       <div className="mt-4 grid grid-cols-1 gap-4 md:grid-cols-2">
                         <label className="block space-y-1.5">
@@ -621,7 +642,7 @@ export function ProjectionGapSimulator() {
                         </label>
                         <label className="block space-y-1.5">
                           <span className="text-xs font-medium text-muted-foreground">
-                            Free-float change (points)
+                            Free-float change (points) / share-count change (%)
                           </span>
                           <input
                             type="text"
@@ -809,6 +830,27 @@ export function ProjectionGapSimulator() {
                         {result.summary}
                       </p>
                     </div>
+
+                    {result.verdict && (
+                      <div className="rounded-2xl border border-primary/35 bg-primary/10 px-4 py-4 sm:px-5 sm:py-5">
+                        <p className="mb-1.5 text-[11px] font-semibold uppercase tracking-wide text-primary">
+                          Verdict
+                        </p>
+                        <p className="text-sm leading-relaxed text-foreground">
+                          {result.verdict}
+                        </p>
+                        {(() => {
+                          const meta = canonicalEventById(input.eventFamily);
+                          if (!meta) return null;
+                          return (
+                            <p className="mt-2 text-[11px] uppercase tracking-wide text-muted-foreground">
+                              {meta.badge} · {meta.category} · {meta.name}
+                            </p>
+                          );
+                        })()}
+                      </div>
+                    )}
+
                     <ul className="space-y-3">
                       {result.hypotheses.map((h) => (
                         <li
@@ -830,6 +872,13 @@ export function ProjectionGapSimulator() {
                               <span className="font-semibold text-foreground">
                                 {h.appliesToVendors.map(vendorAbbr).join(", ")}
                               </span>
+                              {h.citation && (
+                                <>
+                                  <span className="mx-2 text-border">·</span>
+                                  <span className="uppercase tracking-wide">Source: </span>
+                                  <span className="text-foreground">{h.citation}</span>
+                                </>
+                              )}
                             </p>
                           )}
                         </li>

--- a/src/lib/simulator/simulator-engine.ts
+++ b/src/lib/simulator/simulator-engine.ts
@@ -1,18 +1,21 @@
-import type { VendorId } from "@/lib/vendors";
-import { vendorAbbr } from "@/lib/vendors";
+import { canonicalEventById, type CanonicalEventId } from "@/lib/event-taxonomy";
 import { getEventClassFromFamily, humanFamily } from "@/lib/simulator/taxonomy";
 import type {
-  EventFamily,
   Hypothesis,
   Relevance,
   SimulatorInput,
   SimulatorResult,
 } from "@/lib/simulator/types";
+import type { VendorId } from "@/lib/vendors";
+import { vendorAbbr, vendorLabel } from "@/lib/vendors";
+import { getVendorRule, type VendorRule } from "@/lib/simulator/vendor-rules";
 
-const RULES_VERSION = "1.1.1";
+const RULES_VERSION = "2.0.0";
 
 const DISCLAIMER =
-  "This simulator produces possible explanations only. It does not replace official vendor methodology, notices, or your internal policy. Always confirm with vendor documentation and primary sources.";
+  "Simulator output is a deterministic read of the documented vendor rules in SOURCES/index-vendor-methodology.md. It does not replace official vendor notices or your internal policy — always confirm with primary sources.";
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
 
 function formatIsoDate(iso: string): string {
   if (!iso) return "—";
@@ -25,10 +28,7 @@ function formatIsoDate(iso: string): string {
   });
 }
 
-/**
- * Business days strictly after `fromIso` through `toIso` inclusive (Mon–Fri only; ignores holidays).
- */
-function businessDaysAfterThrough(fromIso: string, toIso: string): number | null {
+function businessDaysBetween(fromIso: string, toIso: string): number | null {
   if (!fromIso || !toIso) return null;
   const from = new Date(fromIso + "T12:00:00");
   const to = new Date(toIso + "T12:00:00");
@@ -83,9 +83,168 @@ function parseOptionalPct(raw: string): number | null {
   return n;
 }
 
+// ─── Per-vendor reasoning ───────────────────────────────────────────────────
+
+type VendorVerdict = {
+  vendorId: VendorId;
+  rule: VendorRule;
+  /** Concise sentence saying whether this vendor would publish, and why. */
+  decision: string;
+  /** "publish" = vendor would have a line in the projection feed; "suppress" = not yet. */
+  status: "publish" | "suppress" | "indeterminate";
+};
+
+function judgeVendor(
+  event: CanonicalEventId,
+  vendorId: VendorId,
+  input: SimulatorInput,
+): VendorVerdict | null {
+  const rule = getVendorRule(event, vendorId);
+  if (!rule) return null;
+
+  const yieldPct = parseOptionalPct(input.metrics.dividendYieldPct);
+  const ffDelta = parseOptionalPct(input.metrics.freeFloatChangePp);
+  const tenderPct = parseOptionalPct(input.metrics.tenderAcceptancePct);
+  // Rights discount captured for downstream OTM/ITM heuristics — not yet wired into vendor judgement.
+  void parseOptionalPct(input.metrics.rightsDiscountPct);
+
+  let status: VendorVerdict["status"] = "publish";
+  let decision = rule.reason;
+
+  switch (rule.trigger) {
+    case "always":
+      status = "publish";
+      break;
+
+    case "no-coverage":
+      status = "indeterminate";
+      decision = `${vendorLabel(vendorId)} has no documented path for ${humanFamily(event)} in the sourced methodology — absence in this feed is expected, not anomalous.`;
+      break;
+
+    case "threshold-size": {
+      // Map to whichever metric is meaningful for this event family.
+      const metric =
+        event === "secondary-offering" || event === "private-placement"
+          ? ffDelta
+          : event === "special-dividend"
+            ? yieldPct
+            : null;
+      if (metric === null) {
+        status = "indeterminate";
+        decision = `${vendorLabel(vendorId)}: ${rule.reason} You did not provide a size hint, so the simulator cannot say for certain whether the threshold was crossed.`;
+      } else if (
+        rule.thresholdPct !== undefined &&
+        Math.abs(metric) >= rule.thresholdPct
+      ) {
+        status = "publish";
+        decision = `${vendorLabel(vendorId)}: size ≈ ${metric}% meets the ${rule.thresholdPct}% trigger, so this vendor SHOULD publish a projection line. ${rule.reason}`;
+      } else if (rule.thresholdPct !== undefined) {
+        status = "suppress";
+        decision = `${vendorLabel(vendorId)}: size ≈ ${metric}% is below the ${rule.thresholdPct}% trigger, so the change is deferred to the next quarterly review and will not show in the open-constituents projection feed yet. ${rule.reason}`;
+      }
+      break;
+    }
+
+    case "threshold-recurrence":
+      status = "indeterminate";
+      decision = `${vendorLabel(vendorId)}: classification depends on the consecutive-occurrence count for this issuer (the simulator does not have that history). ${rule.reason}`;
+      break;
+
+    case "threshold-float":
+      if (ffDelta === null) {
+        status = "indeterminate";
+        decision = `${vendorLabel(vendorId)}: ${rule.reason} Add an estimated free-float change to firm up the prediction.`;
+      } else if (
+        rule.thresholdPct !== undefined &&
+        Math.abs(ffDelta) >= rule.thresholdPct
+      ) {
+        status = "publish";
+        decision = `${vendorLabel(vendorId)}: free-float change ≈ ${ffDelta}pp crosses the ${rule.thresholdPct}% threshold, so this vendor should action it — a missing line is unusual. ${rule.reason}`;
+      } else if (rule.thresholdPct !== undefined) {
+        status = "suppress";
+        decision = `${vendorLabel(vendorId)}: free-float change ≈ ${ffDelta}pp is below the ${rule.thresholdPct}% threshold — deferred to the next review and not in the projection feed yet. ${rule.reason}`;
+      }
+      break;
+
+    case "threshold-acceptance":
+      if (tenderPct === null) {
+        status = "indeterminate";
+        decision = `${vendorLabel(vendorId)}: ${rule.reason} Provide an acceptance % to make the prediction definite.`;
+      } else if (
+        rule.thresholdPct !== undefined &&
+        tenderPct >= rule.thresholdPct
+      ) {
+        status = "publish";
+        decision = `${vendorLabel(vendorId)}: acceptance ≈ ${tenderPct}% meets the ${rule.thresholdPct}% trigger — this vendor would already publish the deletion line. ${rule.reason}`;
+      } else if (rule.thresholdPct !== undefined) {
+        status = "suppress";
+        decision = `${vendorLabel(vendorId)}: acceptance ≈ ${tenderPct}% is below the ${rule.thresholdPct}% trigger — no deletion line in the projection feed yet. ${rule.reason}`;
+      }
+      break;
+
+    case "itm-only":
+      if (input.rightsItm === "otm") {
+        status = "suppress";
+        decision = `${vendorLabel(vendorId)}: rights are OUT-OF-THE-MONEY, so this vendor does NOT adjust — absence in the feed is expected and correct. ${rule.reason}`;
+      } else if (input.rightsItm === "itm") {
+        status = "publish";
+        decision = `${vendorLabel(vendorId)}: rights are IN-THE-MONEY, so this vendor DOES adjust — a missing line would be a true gap. ${rule.reason}`;
+      } else {
+        status = "indeterminate";
+        decision = `${vendorLabel(vendorId)}: ITM/OTM is unconfirmed in the inputs. ${rule.reason}`;
+      }
+      break;
+
+    case "completion-gate":
+      status = "indeterminate";
+      decision = `${vendorLabel(vendorId)}: ${rule.reason} Until the deal/offer is unconditional, missing-from-projection is the documented behaviour, not a gap.`;
+      break;
+
+    case "scheduled-review":
+      status = "suppress";
+      decision = `${vendorLabel(vendorId)}: this event is batched into the next scheduled review — absence in the open-constituents projection is expected. ${rule.reason}`;
+      break;
+
+    case "placeholder-immediate":
+      status = "publish";
+      decision = `${vendorLabel(vendorId)}: this vendor adds the line immediately at a placeholder price — a missing entry is unusual unless the event is outside the T-5 window. ${rule.reason}`;
+      break;
+
+    case "wait-real-trade":
+      if (input.spinoffPhase === "live_trade") {
+        status = "publish";
+        decision = `${vendorLabel(vendorId)}: the child is in regular trading, so this vendor should now have a real-price line. ${rule.reason}`;
+      } else {
+        status = "suppress";
+        decision = `${vendorLabel(vendorId)}: the child is still in placeholder/when-issued phase, so this vendor will not add it until first real trade. ${rule.reason}`;
+      }
+      break;
+
+    case "estimated-price":
+      status = "publish";
+      decision = `${vendorLabel(vendorId)}: this vendor uses an estimated price until real trading begins — the line should be present. ${rule.reason}`;
+      break;
+
+    case "direct-price-adj":
+      status = "publish";
+      decision = `${vendorLabel(vendorId)}: applies a direct price adjustment rather than a separate line — if you are looking for a dividend line you will not find one here even though the index level is adjusted. ${rule.reason}`;
+      break;
+
+    case "notice-required":
+      status = "suppress";
+      decision = `${vendorLabel(vendorId)}: requires ${rule.noticeDays ?? 2} trading days of advance notice — even when the threshold is met, the deletion line lags peers by that many days. ${rule.reason}`;
+      break;
+  }
+
+  return { vendorId, rule, decision, status };
+}
+
+// ─── Verdict / summary ──────────────────────────────────────────────────────
+
 function buildSummary(input: SimulatorInput): string {
   const cls = getEventClassFromFamily(input.eventFamily);
-  const eventUpper = `${cls.toUpperCase()} · ${humanFamily(input.eventFamily).toUpperCase()}`;
+  const meta = canonicalEventById(input.eventFamily);
+  const eventUpper = `${cls.toUpperCase()} · ${(meta?.name ?? humanFamily(input.eventFamily)).toUpperCase()}`;
   const eff = formatIsoDate(input.effectiveDate);
   const miss = input.missingVendors.map(vendorAbbr).join(" + ") || "—";
   const pres = input.presentVendors.map(vendorAbbr).join(" + ") || "—";
@@ -95,24 +254,68 @@ function buildSummary(input: SimulatorInput): string {
   return `${eventUpper} | ${eff} eff | ${miss}: ABSENT ←→ ${pres}: PRESENT${note}`;
 }
 
+function buildVerdict(
+  input: SimulatorInput,
+  judgements: Map<VendorId, VendorVerdict>,
+): string {
+  const meta = canonicalEventById(input.eventFamily);
+  const event = meta?.name ?? humanFamily(input.eventFamily);
+  const missing = input.missingVendors;
+  const present = input.presentVendors;
+
+  const missingExpected = missing
+    .map((v) => judgements.get(v))
+    .filter(
+      (j): j is VendorVerdict =>
+        j !== undefined && (j.status === "suppress" || j.status === "indeterminate"),
+    );
+  const missingUnexpected = missing
+    .map((v) => judgements.get(v))
+    .filter((j): j is VendorVerdict => j !== undefined && j.status === "publish");
+  const presentExpected = present
+    .map((v) => judgements.get(v))
+    .filter((j): j is VendorVerdict => j !== undefined && j.status === "publish");
+
+  if (missing.length === 0 && present.length === 0) {
+    return `Pick at least one vendor in each column so the simulator can compare ${event} treatments side by side.`;
+  }
+
+  if (missingUnexpected.length > 0) {
+    const names = missingUnexpected.map((j) => vendorLabel(j.vendorId)).join(", ");
+    return `Likely a true data gap: ${names} ${missingUnexpected.length === 1 ? "should" : "should each"} have published this ${event} based on its documented rule, so the absence is anomalous and worth escalating.`;
+  }
+
+  if (missingExpected.length > 0 && presentExpected.length > 0) {
+    const expectedNames = missingExpected.map((j) => vendorLabel(j.vendorId)).join(", ");
+    const presentNames = presentExpected.map((j) => vendorLabel(j.vendorId)).join(", ");
+    return `Methodology divergence — not a data gap: ${expectedNames} ${missingExpected.length === 1 ? "is" : "are"} CORRECTLY silent under its own ${event} rule, while ${presentNames} ${presentExpected.length === 1 ? "is" : "are"} CORRECTLY publishing under theirs. The same event hits different thresholds.`;
+  }
+
+  if (missingExpected.length > 0) {
+    const names = missingExpected.map((j) => vendorLabel(j.vendorId)).join(", ");
+    return `Expected silence: ${names} ${missingExpected.length === 1 ? "follows a rule" : "each follow a rule"} that defers or suppresses this ${event} in the projection feed — absence here is the documented behaviour.`;
+  }
+
+  return `${event}: every selected vendor is acting consistently with its documented rule — the divergence may be timing or feed lag rather than methodology.`;
+}
+
+// ─── Engine ─────────────────────────────────────────────────────────────────
+
 export function runSimulator(input: SimulatorInput): SimulatorResult {
   const hypotheses: Hypothesis[] = [];
+  const event = input.eventFamily as CanonicalEventId;
+
   const { onlyMissing, onlyPresent } = onlyMissingPresent(
     input.missingVendors,
     input.presentVendors,
   );
-  const eventClass = getEventClassFromFamily(input.eventFamily);
-  const divYield = parseOptionalPct(input.metrics.dividendYieldPct);
-  const ffDelta = parseOptionalPct(input.metrics.freeFloatChangePp);
-  const tenderPct = parseOptionalPct(input.metrics.tenderAcceptancePct);
-  const rightsDisc = parseOptionalPct(input.metrics.rightsDiscountPct);
 
   const dup = overlap(input.missingVendors, input.presentVendors);
   if (dup.length > 0) {
     hypotheses.push({
       id: "input-overlap",
       title: "OVERLAPPING VENDOR SELECTION",
-      explanation: `The same vendor cannot be both "missing" and "sent projection" for this exercise: ${listVendors(dup)}. Adjust the selections so each vendor is in at most one list; other hypotheses below assume non-overlapping lists.`,
+      explanation: `The same vendor cannot be both "missing" and "sent projection" for this exercise: ${listVendors(dup)}. Adjust the selections so each vendor is in at most one list; the verdict assumes non-overlapping lists.`,
       relevance: "high",
       appliesToVendors: dup,
     });
@@ -123,267 +326,122 @@ export function runSimulator(input: SimulatorInput): SimulatorResult {
       id: "no-gap",
       title: "NO GAP SELECTED",
       explanation:
-        "Select at least one vendor that appears missing and one that sent a projection file so the simulator can contrast behaviour. If everyone is aligned, divergence may be timing-only or already resolved.",
+        "Select at least one vendor that appears missing and one that already sent a file so the engine can contrast their documented rules.",
       relevance: "medium",
       appliesToVendors: [],
     });
   }
 
-  const bdDataToEffective = businessDaysAfterThrough(input.dataAsOf, input.effectiveDate);
+  const judgements = new Map<VendorId, VendorVerdict>();
+  for (const v of [...input.missingVendors, ...input.presentVendors]) {
+    if (judgements.has(v)) continue;
+    const j = judgeVendor(event, v, input);
+    if (j) judgements.set(v, j);
+  }
+
+  // One hypothesis per missing vendor — high relevance — explaining why it is silent.
+  for (const v of onlyMissing) {
+    const j = judgements.get(v);
+    if (!j) continue;
+    hypotheses.push({
+      id: `missing-${v}`,
+      title: `${vendorLabel(v).toUpperCase()} — ${j.status === "publish" ? "TRUE GAP" : j.status === "suppress" ? "EXPECTED SILENCE" : "AMBIGUOUS"}`,
+      explanation: j.decision,
+      relevance: j.status === "publish" ? "high" : "medium",
+      appliesToVendors: [v],
+      citation: j.rule.citation,
+    });
+  }
+
+  // One hypothesis per present vendor — medium relevance — explaining why it published.
+  for (const v of onlyPresent) {
+    const j = judgements.get(v);
+    if (!j) continue;
+    hypotheses.push({
+      id: `present-${v}`,
+      title: `${vendorLabel(v).toUpperCase()} — PUBLISHED PER RULE`,
+      explanation: j.decision,
+      relevance: "medium",
+      appliesToVendors: [v],
+      citation: j.rule.citation,
+    });
+  }
+
+  // ── Cross-cutting timing checks (unchanged from v1.x) ────────────────────
+  const bdDataToEffective = businessDaysBetween(input.dataAsOf, input.effectiveDate);
   if (bdDataToEffective !== null && bdDataToEffective > 5) {
     hypotheses.push({
       id: "t5-window",
       title: "T-5 WINDOW EXCEEDED",
-      explanation: `Your "as of" data date (${formatIsoDate(input.dataAsOf)}) is more than five business days before the effective date (${formatIsoDate(input.effectiveDate)}). Vendors often publish open-constituent projections for events within a forward window from the data date. Events far outside that window may not appear in some feeds yet, even if others publish earlier placeholders or notices.`,
+      explanation: `Your "as of" data date (${formatIsoDate(input.dataAsOf)}) is ${bdDataToEffective} business days before the effective date (${formatIsoDate(input.effectiveDate)}) — outside the documented T-5 forward window. Vendors with strict T-5 publication will not yet have this line in the open-constituents projection.`,
       relevance: "high",
       appliesToVendors: onlyMissing,
+      citation: "Vendor Coverage Overview (T-5)",
     });
   }
 
   if (input.exDate && input.dataAsOf) {
-    const bdToEx = businessDaysAfterThrough(input.dataAsOf, input.exDate);
+    const bdToEx = businessDaysBetween(input.dataAsOf, input.exDate);
     if (bdToEx !== null && bdToEx > 5) {
       hypotheses.push({
         id: "ex-before-coverage",
-        title: "EX-DATE FAR FROM SNAPSHOT",
-        explanation: `Ex-date is ${formatIsoDate(input.exDate)} relative to data as of ${formatIsoDate(input.dataAsOf)}. Some vendors emphasise ex-date adjustments and grace-period logic; others may delay spin-off child lines until first trade. A large gap between snapshot and ex-date can produce "missing now, appears later" patterns.`,
+        title: "EX-DATE OUTSIDE COVERAGE WINDOW",
+        explanation: `Ex-date (${formatIsoDate(input.exDate)}) is ${bdToEx} business days from the as-of date (${formatIsoDate(input.dataAsOf)}). Even vendors that would normally publish may not yet show this event because it falls outside their T-5 forward window.`,
         relevance: "medium",
         appliesToVendors: onlyMissing,
       });
     }
   }
 
-  if (eventClass === "voluntary") {
+  // ── Event-specific contextual notes ─────────────────────────────────────
+  if (event === "rights-issue" && !input.rightsSubscriptionKnown) {
     hypotheses.push({
-      id: "voluntary-uncertainty",
-      title: "VOLUNTARY EVENT — PARTICIPATION OPEN",
+      id: "rights-unknown-terms",
+      title: "RIGHTS — TERMS NOT FINAL",
       explanation:
-        "Rights issues, tenders, and similar voluntary actions often need confirmed subscription or acceptance before every vendor adjusts floats or share counts. One feed may show an early or provisional line while another waits for final results — especially where free-float or materiality thresholds differ.",
+        "Final subscription price/ratio are not yet confirmed. Vendors that gate on terms (MSCI, Morningstar, Solactive) typically suppress projection updates until terms are final; FTSE may publish a provisional nil-paid line.",
+      relevance: "medium",
+      appliesToVendors: onlyMissing,
+    });
+  }
+
+  if (event === "merger" && input.mnaIndexParties === "both") {
+    hypotheses.push({
+      id: "mna-both-deletion-triggers",
+      title: "M&A — TARGET + ACQUIRER BOTH IN INDEX",
+      explanation:
+        "Because both parties are constituents, the divergence is dominated by the deletion threshold (S&P Float<15% OR ≥90%, FTSE ≥90% OR Float<5%, STOXX BOTH ≥85% AND Float<10%). Same deal — different effective removal dates by design.",
       relevance: "high",
-      appliesToVendors: onlyMissing,
+      appliesToVendors: [...onlyMissing, ...onlyPresent],
+      citation: "§11",
     });
   }
 
-  if (input.eventFamily === "dividend" && divYield !== null) {
-    if (input.dividendFlavor === "special" && divYield >= 5) {
-      hypotheses.push({
-        id: "div-yield-special-large",
-        title: "LARGE SPECIAL DIVIDEND",
-        explanation: `You indicated a dividend yield of about ${divYield}% of price. A large special distribution can change how vendors classify the event (e.g. return of capital vs dividend) and whether it is deferred or treated across PR vs TR series. Some feeds wait for confirmed gross or net amounts before publishing a projection line.`,
-        relevance: "high",
-        appliesToVendors: onlyMissing,
-      });
-    } else if (divYield >= 3 && input.dividendFlavor !== "ordinary") {
-      hypotheses.push({
-        id: "div-yield-material",
-        title: "MATERIAL DIVIDEND — THRESHOLD RISK",
-        explanation: `A dividend of roughly ${divYield}% of price may cross materiality thresholds for some vendors but not others, or may be handled differently on PR vs TR. Below-threshold amounts can be deferred to the next review cycle on some indices.`,
-        relevance: "medium",
-        appliesToVendors: onlyMissing,
-      });
-    }
+  if (event === "merger" && input.mnaIndexParties === "acquirer_only") {
+    hypotheses.push({
+      id: "mna-acquirer-only",
+      title: "M&A — ACQUIRER-ONLY INDEX",
+      explanation:
+        "With only the acquirer in the index, deletion thresholds are irrelevant — what matters is the acquirer share-count change. MSCI uses 5%/10%/25% by cap tier; STOXX/FTSE flag extraordinary float changes ≥5pp.",
+      relevance: "medium",
+      appliesToVendors: [...onlyMissing, ...onlyPresent],
+      citation: "§11 Scenario C",
+    });
   }
 
-  if (ffDelta !== null && Math.abs(ffDelta) >= 5) {
+  if (event === "spin-off" && input.spinoffChildEligible === "no") {
     hypotheses.push({
-      id: "float-delta",
-      title: "FREE-FLOAT CHANGE DETECTED",
-      explanation: `You entered about ${ffDelta >= 0 ? "+" : ""}${ffDelta} percentage points of free-float change. Several vendors apply extraordinary float adjustments or different timing when float moves by roughly five points or more. That alone can explain why one feed already reflects a line and another does not.`,
+      id: "spinoff-ineligible",
+      title: "SPIN-OFF CHILD INELIGIBLE",
+      explanation:
+        "If the distributed security is not index-eligible (sector, liquidity, domicile), no vendor adds a child line — the only line you should expect is the parent price adjustment.",
       relevance: "high",
-      appliesToVendors: onlyMissing,
+      appliesToVendors: input.missingVendors,
+      citation: "§6",
     });
   }
 
-  if (input.eventFamily === "tender" && tenderPct !== null) {
-    if (tenderPct < 50) {
-      hypotheses.push({
-        id: "tender-low",
-        title: "LOW TENDER ACCEPTANCE",
-        explanation: `With acceptance around ${tenderPct}%, some methodologies will not treat the offer as sufficiently progressed to adjust or delete lines, while others may publish provisional scenarios. Divergence often appears around the acceptance thresholds each vendor publishes.`,
-        relevance: "medium",
-        appliesToVendors: onlyMissing,
-      });
-    } else if (tenderPct >= 85) {
-      hypotheses.push({
-        id: "tender-high",
-        title: "HIGH ACCEPTANCE — TIMING DIVERGES",
-        explanation: `Around ${tenderPct}% acceptance often crosses key thresholds, but vendors still disagree on when a target line is removed or when float is updated — especially if conditions combine acceptance % with free-float tests.`,
-        relevance: "medium",
-        appliesToVendors: onlyMissing,
-      });
-    }
-  }
-
-  if (input.eventFamily === "rights" && rightsDisc !== null && rightsDisc > 0) {
-    hypotheses.push({
-      id: "rights-discount",
-      title: "RIGHTS BELOW THEORETICAL",
-      explanation: `You noted the rights trade roughly ${rightsDisc}% below theoretical value. Deep discounts can correlate with low exercise expectations; some vendors delay or omit adjustments until the outcome is clearer, while others publish nil-paid lines earlier.`,
-      relevance: "low",
-      appliesToVendors: onlyMissing,
-    });
-  }
-
-  if (input.eventFamily === "merger") {
-    if (input.mnaIndexParties === "both") {
-      hypotheses.push({
-        id: "mna-both-deletion-triggers",
-        title: "M&A: TARGET + ACQUIRER IN INDEX",
-        explanation:
-          "When target and acquirer are both index constituents, deletion and float rules diverge materially across vendors (e.g. different combinations of acceptance % and free-float conditions). The same deal can therefore show different effective removal dates or interim placeholder treatment in projections.",
-        relevance: "high",
-        appliesToVendors: onlyMissing,
-      });
-    }
-    if (input.mnaIndexParties === "acquirer_only") {
-      hypotheses.push({
-        id: "mna-acquirer-only",
-        title: "M&A: ACQUIRER-ONLY INDEX",
-        explanation:
-          "If only the acquirer is in the index, vendors still disagree on how and when to reflect share count and float changes for stock vs cash consideration, and on confirmation gates. One feed may show an early divisor-related adjustment while another waits for settlement or exchange confirmation.",
-        relevance: "medium",
-        appliesToVendors: onlyMissing,
-      });
-    }
-    if (input.mnaDealType === "cash") {
-      hypotheses.push({
-        id: "mna-cash",
-        title: "CASH DEAL — DIFFERENT ADJUSTMENT",
-        explanation:
-          "Cash mergers are often treated differently from stock mergers for divisor and continuity. A vendor that already published a projection line may be using a different confirmation or price basis than one that is still silent.",
-        relevance: "medium",
-        appliesToVendors: onlyMissing,
-      });
-    }
-  }
-
-  if (input.eventFamily === "spinoff") {
-    if (input.spinoffChildEligible === "no") {
-      hypotheses.push({
-        id: "spinoff-ineligible",
-        title: "SPIN-OFF CHILD INELIGIBLE",
-        explanation:
-          "If the distributed security is not index-eligible (sector, liquidity, domicile), many methodologies never add a child line in projections. Missing vendors may simply not publish a placeholder for a security outside index rules.",
-        relevance: "high",
-        appliesToVendors: onlyMissing,
-      });
-    } else if (input.spinoffChildEligible === "yes") {
-      hypotheses.push({
-        id: "spinoff-placeholder-vs-trade",
-        title: "SPIN-OFF: PLACEHOLDER VS LIVE TRADE",
-        explanation:
-          "For an eligible spin-off child, vendors disagree on zero vs estimated vs when-issued pricing, and on how long to wait for real trading. Vendors that use immediate placeholders often appear in feeds earlier than those that require a live market price.",
-        relevance: "high",
-        appliesToVendors: onlyMissing,
-      });
-      if (input.spinoffPhase === "placeholder") {
-        hypotheses.push({
-          id: "spinoff-phase-placeholder",
-          title: "SPIN-OFF: STILL IN PLACEHOLDER PHASE",
-          explanation:
-            "If the child has not yet traded regularly, vendors that require a market price may omit the line from projections until first trade, while others already show a floor or estimated price.",
-          relevance: "high",
-          appliesToVendors: onlyMissing,
-        });
-      }
-    }
-  }
-
-  if (input.eventFamily === "rights") {
-    if (input.rightsItm === "otm") {
-      hypotheses.push({
-        id: "rights-otm",
-        title: "OTM RIGHTS — VENDORS IGNORE",
-        explanation:
-          "OTM rights are often economically irrelevant for index replication; several methodologies do not adjust until or unless terms change or the issue becomes in-the-money. A vendor showing nothing may be consistent with that policy.",
-        relevance: "high",
-        appliesToVendors: onlyMissing,
-      });
-    } else if (input.rightsItm === "itm") {
-      hypotheses.push({
-        id: "rights-itm",
-        title: "ITM RIGHTS — TIMING + FLOAT DIVERGE",
-        explanation:
-          "ITM rights usually require attention, but vendors still differ on nil-paid lines, subscription results, and free-float effects from non-participation. One vendor may publish a provisional line while another waits for final take-up.",
-        relevance: "medium",
-        appliesToVendors: onlyMissing,
-      });
-    }
-    if (!input.rightsSubscriptionKnown) {
-      hypotheses.push({
-        id: "rights-unknown-terms",
-        title: "Incomplete terms — vendor gating",
-        explanation:
-          "If subscription price or ratio is not yet final, some vendors suppress projection updates until terms are confirmed, while others publish provisional lines subject to revision.",
-        relevance: "medium",
-        appliesToVendors: onlyMissing,
-      });
-    }
-  }
-
-  if (input.eventFamily === "dividend") {
-    if (input.dividendFlavor === "special") {
-      hypotheses.push({
-        id: "div-special",
-        title: "Special dividend — different treatment vs ordinary",
-        explanation:
-          "Special dividends can be classified and adjusted differently across vendors (price return vs total return series, timing vs ex-date, and materiality). A vendor missing the line may be applying a different event classification or waiting for confirmed gross or net amounts.",
-        relevance: "medium",
-        appliesToVendors: onlyMissing,
-      });
-    }
-    if (input.indexReturnVariant !== "unknown") {
-      hypotheses.push({
-        id: "div-pr-tr-ntr",
-        title: "PR vs TR vs NTR series",
-        explanation:
-          "Dividend impact is most visible on total-return variants. If you are comparing price-return screens to TR or NTR feeds, apparent mismatches can be series selection rather than missing corporate action data.",
-        relevance: "low",
-        appliesToVendors: onlyMissing,
-      });
-    }
-  }
-
-  if (input.eventFamily === "other" || input.eventFamily === "delisting" || input.eventFamily === "tender") {
-    hypotheses.push({
-      id: "generic-methodology",
-      title: "Methodology or feed lag",
-      explanation:
-        "For less common or boundary cases, divergence often comes down to confirmation gates, exchange notices, or feed publication lag rather than disagreement on the economic event. Compare vendor timing tables and check whether the missing feed has published any notice without yet updating open constituents.",
-      relevance: "low",
-      appliesToVendors: onlyMissing,
-    });
-  }
-
-  if (input.eventFamily === "split") {
-    hypotheses.push({
-      id: "split-timing",
-      title: "Split ratio confirmation",
-      explanation:
-        "Stock splits are usually straightforward once confirmed, but vendors can still differ on the snapshot date used for divisor adjustment vs when the split first appears in projection files.",
-      relevance: "low",
-      appliesToVendors: onlyMissing,
-    });
-  }
-
-  const pilotFamilies: EventFamily[] = [
-    "dividend",
-    "split",
-    "merger",
-    "spinoff",
-    "rights",
-  ];
-  if (!pilotFamilies.includes(input.eventFamily)) {
-    hypotheses.push({
-      id: "pilot-stub",
-      title: "Broader reference may be needed",
-      explanation:
-        "The richest rule set here focuses on dividends, splits, M&A, spin-offs, and rights. For this event type, lean on the vendor reference for thresholds and timing, and treat simulator output as a starting point.",
-      relevance: "low",
-      appliesToVendors: onlyMissing,
-    });
-  }
-
+  // ── Sort, dedup, finalise ───────────────────────────────────────────────
   const dedup = new Map<string, Hypothesis>();
   for (const h of hypotheses) {
     if (!dedup.has(h.id)) dedup.set(h.id, h);
@@ -400,7 +458,8 @@ export function runSimulator(input: SimulatorInput): SimulatorResult {
 
   return {
     summary: buildSummary(input),
-    hypotheses: sorted.slice(0, 8),
+    verdict: buildVerdict(input, judgements),
+    hypotheses: sorted.slice(0, 12),
     nextStepLinks,
     disclaimer: DISCLAIMER,
     rulesVersion: RULES_VERSION,

--- a/src/lib/simulator/taxonomy.ts
+++ b/src/lib/simulator/taxonomy.ts
@@ -1,34 +1,33 @@
+import {
+  CANONICAL_EVENTS,
+  canonicalEventById,
+  type CanonicalEventId,
+  type EventBadge,
+} from "@/lib/event-taxonomy";
 import type { EventClass, EventFamily } from "@/lib/simulator/types";
 
 /**
- * Coarse simulator families (not the full 13-type vendor list).
- * Canonical names and mandatory/voluntary counts live in `@/lib/event-taxonomy`.
+ * Single source of truth: every simulator family IS a canonical event id from
+ * `@/lib/event-taxonomy` (the same 13 ISO CAEV types the Vendor Reference uses).
+ * The simulator no longer maintains its own coarse taxonomy.
  */
 
-/** Event class is determined by the selected family — no separate user step. */
-export const FAMILY_TO_CLASS: Record<EventFamily, EventClass> = {
-  dividend: "mandatory",
-  split: "mandatory",
-  merger: "mandatory",
-  spinoff: "mandatory",
-  return_of_capital: "mandatory",
-  delisting: "mandatory",
-  rights: "voluntary",
-  tender: "voluntary",
-  other: "mandatory",
+const BADGE_TO_CLASS: Record<EventBadge, EventClass> = {
+  mandatory: "mandatory",
+  voluntary: "voluntary",
 };
 
-export const MANDATORY_FAMILIES: EventFamily[] = [
-  "dividend",
-  "split",
-  "merger",
-  "spinoff",
-  "return_of_capital",
-  "delisting",
-  "other",
-];
+export const FAMILY_TO_CLASS: Record<EventFamily, EventClass> = Object.fromEntries(
+  CANONICAL_EVENTS.map((e) => [e.id, BADGE_TO_CLASS[e.badge]]),
+) as Record<EventFamily, EventClass>;
 
-export const VOLUNTARY_FAMILIES: EventFamily[] = ["rights", "tender"];
+export const MANDATORY_FAMILIES: EventFamily[] = CANONICAL_EVENTS.filter(
+  (e) => e.badge === "mandatory",
+).map((e) => e.id as CanonicalEventId);
+
+export const VOLUNTARY_FAMILIES: EventFamily[] = CANONICAL_EVENTS.filter(
+  (e) => e.badge === "voluntary",
+).map((e) => e.id as CanonicalEventId);
 
 export function getEventClassFromFamily(family: EventFamily): EventClass {
   return FAMILY_TO_CLASS[family] ?? "mandatory";
@@ -39,16 +38,5 @@ export function familiesForClass(eventClass: EventClass): EventFamily[] {
 }
 
 export function humanFamily(f: EventFamily): string {
-  const map: Record<EventFamily, string> = {
-    dividend: "Dividend",
-    split: "Stock split or consolidation",
-    merger: "M&A",
-    spinoff: "Spin-off",
-    rights: "Rights issue",
-    tender: "Tender or buyback",
-    return_of_capital: "Return of capital",
-    delisting: "Delisting",
-    other: "Other corporate action",
-  };
-  return map[f];
+  return canonicalEventById(f)?.name ?? f;
 }

--- a/src/lib/simulator/types.ts
+++ b/src/lib/simulator/types.ts
@@ -1,17 +1,15 @@
+import type { CanonicalEventId } from "@/lib/event-taxonomy";
 import type { VendorId } from "@/lib/vendors";
 
 export type EventClass = "mandatory" | "voluntary";
 
-export type EventFamily =
-  | "dividend"
-  | "split"
-  | "merger"
-  | "spinoff"
-  | "rights"
-  | "tender"
-  | "return_of_capital"
-  | "delisting"
-  | "other";
+/**
+ * The simulator’s event family is the canonical 13-type ISO CAEV taxonomy
+ * defined in `@/lib/event-taxonomy` — same ids the Vendor Reference uses.
+ * This guarantees the simulator, the homepage decision tree, and the vendor
+ * comparison page stay in lockstep.
+ */
+export type EventFamily = CanonicalEventId;
 
 /** Rights issue sub-options */
 export type RightsItm = "itm" | "otm" | "unknown";
@@ -24,8 +22,7 @@ export type MnaIndexParties = "target_only" | "acquirer_only" | "both";
 export type SpinoffChildEligible = "yes" | "no" | "unknown";
 export type SpinoffPhase = "placeholder" | "live_trade" | "unknown";
 
-/** Dividend sub-options */
-export type DividendFlavor = "ordinary" | "special" | "unknown";
+/** Dividend sub-options — applies to cash-dividend & special-dividend */
 export type IndexReturnVariant = "pr" | "tr" | "ntr" | "unknown";
 
 export type Relevance = "high" | "medium" | "low";
@@ -49,7 +46,6 @@ export type SimulatorInput = {
   mnaIndexParties: MnaIndexParties;
   spinoffChildEligible: SpinoffChildEligible;
   spinoffPhase: SpinoffPhase;
-  dividendFlavor: DividendFlavor;
   indexReturnVariant: IndexReturnVariant;
   metrics: SimulatorMetrics;
   effectiveDate: string; // YYYY-MM-DD
@@ -66,10 +62,14 @@ export type Hypothesis = {
   explanation: string;
   relevance: Relevance;
   appliesToVendors: VendorId[];
+  /** Optional pointer to the methodology section that backs the explanation. */
+  citation?: string;
 };
 
 export type SimulatorResult = {
   summary: string;
+  /** One short, definite sentence stating WHY the divergence occurred. */
+  verdict: string;
   hypotheses: Hypothesis[];
   nextStepLinks: { label: string; href: string }[];
   disclaimer: string;

--- a/src/lib/simulator/vendor-rules.ts
+++ b/src/lib/simulator/vendor-rules.ts
@@ -1,0 +1,718 @@
+/**
+ * Vendor rule table — used by the simulator engine to produce concrete,
+ * vendor-named explanations. Rules are derived from
+ * `SOURCES/index-vendor-methodology.md` (§1–§13) and mirror the threshold
+ * tables shown on `/vendors/`. Keep this file aligned with both.
+ */
+
+import type { CanonicalEventId } from "@/lib/event-taxonomy";
+import type { VendorId } from "@/lib/vendors";
+
+export type Trigger =
+  | "always" // vendor publishes/adjusts unconditionally for this event
+  | "threshold-size" // depends on a size / materiality threshold
+  | "threshold-recurrence" // depends on consecutive-occurrence rule
+  | "threshold-float" // depends on free-float % of target/issuer
+  | "threshold-acceptance" // depends on tender / acceptance %
+  | "itm-only" // only adjusts in-the-money rights
+  | "completion-gate" // waits for unconditional / completion confirmation
+  | "scheduled-review" // batched into QIR / semi-annual review
+  | "placeholder-immediate" // adds child immediately at a placeholder
+  | "wait-real-trade" // waits for first real market price
+  | "estimated-price" // adds at an estimated price
+  | "direct-price-adj" // direct price adjustment, no separate line
+  | "notice-required" // requires N trading-day advance notice
+  | "no-coverage"; // not documented for this vendor
+
+export type Citation = string;
+
+export type VendorRule = {
+  /** Short headline shown in the simulator card. Must read as a definite rule. */
+  rule: string;
+  /** Trigger mechanism — used by the engine to decide which numeric hint to evaluate. */
+  trigger: Trigger;
+  /** Numeric threshold in %, where applicable (free float, size, acceptance). */
+  thresholdPct?: number;
+  /** Consecutive-occurrence cap, where applicable (e.g. S&P 2 = 1st-2nd free passes). */
+  recurrenceFreePasses?: number;
+  /** Notice period in trading days, where applicable. */
+  noticeDays?: number;
+  /** Plain-language sentence the engine inserts into hypotheses verbatim. */
+  reason: string;
+  /** Methodology citation (section number from the canonical source). */
+  citation?: Citation;
+};
+
+type EventRuleSet = Partial<Record<VendorId, VendorRule>>;
+
+export const VENDOR_RULES: Record<CanonicalEventId, EventRuleSet> = {
+  // ─── §1 Cash Dividend (Regular) ────────────────────────────────────────────
+  "cash-dividend": {
+    msci: {
+      rule: "Ex-date — TR/NTR reinvested, no PR adjustment",
+      trigger: "always",
+      reason:
+        "MSCI applies regular cash dividends on ex-date with no PR adjustment; TR/NTR reinvest gross/net of withholding tax.",
+      citation: "MSCI Corporate Events §1",
+    },
+    sp: {
+      rule: "Ex-date — TR/NTR reinvested, no PR adjustment",
+      trigger: "always",
+      reason:
+        "S&P DJI applies regular cash dividends on ex-date with no PR adjustment; TR/NTR reinvest.",
+      citation: "S&P Equity Indices Policies §1",
+    },
+    ftse: {
+      rule: "Ex-date — TR/NTR reinvested, no PR adjustment",
+      trigger: "always",
+      reason:
+        "FTSE Russell applies regular cash dividends on ex-date with no PR adjustment; TR/NTR reinvest.",
+      citation: "FTSE CA Guide §1",
+    },
+    stoxx: {
+      rule: "GR/NTR reinvested via padj formula — PR not adjusted",
+      trigger: "always",
+      reason:
+        "STOXX uses padj = pt-1 - Divt for GR and pt-1 - Divt × (1-τ) for NTR; the PR series is not adjusted for regular cash dividends.",
+      citation: "STOXX Calc Guide §8.1",
+    },
+    solactive: {
+      rule: "Per Equity Index Methodology — ex-date",
+      trigger: "always",
+      reason:
+        "Solactive applies regular cash dividends per its Equity Index Methodology on ex-date.",
+      citation: "Solactive GPR Global 100 §1",
+    },
+    morningstar: {
+      rule: "Ex-date — TR/NTR reinvested, no PR adjustment",
+      trigger: "always",
+      reason:
+        "Morningstar applies regular cash dividends on ex-date with no PR adjustment.",
+      citation: "Morningstar CA §1",
+    },
+    vettafi: {
+      rule: "Per index methodology — ex-date",
+      trigger: "always",
+      reason:
+        "VettaFi applies regular cash dividends per the relevant ETF benchmark methodology.",
+    },
+  },
+
+  // ─── §2 Special Cash Dividend ──────────────────────────────────────────────
+  "special-dividend": {
+    msci: {
+      rule: "PR adjusted only if ≥5% of price",
+      trigger: "threshold-size",
+      thresholdPct: 5,
+      reason:
+        "MSCI classifies a cash dividend as special only when it is ≥5% of market price; below 5% it is treated as ordinary and the PR index is not adjusted.",
+      citation: "MSCI Corporate Events §2",
+    },
+    sp: {
+      rule: "1st-2nd consecutive free; 4th+ becomes ordinary",
+      trigger: "threshold-recurrence",
+      recurrenceFreePasses: 2,
+      reason:
+        "S&P DJI gives the first two consecutive specials a free pass, treats the third as the last special, and then reclassifies the fourth onwards as ordinary — so the same cash distribution can appear special at one issuer and ordinary at another.",
+      citation: "S&P Equity Indices Policies §2",
+    },
+    ftse: {
+      rule: "1st-3rd consecutive free; 4th+ becomes ordinary",
+      trigger: "threshold-recurrence",
+      recurrenceFreePasses: 3,
+      reason:
+        "FTSE Russell is the most generous: three consecutive specials before a recurring one is treated as ordinary.",
+      citation: "FTSE CA Guide §2",
+    },
+    stoxx: {
+      rule: "PR ALWAYS adjusted — no threshold",
+      trigger: "always",
+      reason:
+        "STOXX is the unique outlier: it applies padj = pt-1 - Divt × (1-τ) to PR for every special dividend, regardless of size or recurrence — so STOXX shows price-return adjustments others suppress.",
+      citation: "STOXX Calc Guide §8.1.1",
+    },
+    solactive: {
+      rule: "Case-by-case per methodology",
+      trigger: "completion-gate",
+      reason:
+        "Solactive treats specials case-by-case; smaller distributions may not surface as a separate line in the projection feed.",
+      citation: "Solactive GPR Global 100 §2",
+    },
+    morningstar: {
+      rule: "PR adjusted only if ≥5% of price (since Aug 2024)",
+      trigger: "threshold-size",
+      thresholdPct: 5,
+      reason:
+        "Morningstar moved to a 5% size threshold in August 2024; below 5% the special is treated as ordinary and the PR index is not adjusted.",
+      citation: "Morningstar CA §2",
+    },
+    vettafi: {
+      rule: "Always classified as special — PR adjusted",
+      trigger: "always",
+      reason:
+        "VettaFi always classifies the distribution as special and always adjusts PR.",
+    },
+  },
+
+  // ─── §3 Stock Dividend ─────────────────────────────────────────────────────
+  "stock-dividend": {
+    msci: {
+      rule: "Treated identically to a stock split",
+      trigger: "always",
+      reason:
+        "MSCI uses the split formula padj = pt-1 × A/(A+B); there is no distinction from bonus.",
+      citation: "MSCI §3",
+    },
+    sp: {
+      rule: "Treated identically to a stock split",
+      trigger: "always",
+      reason:
+        "S&P DJI applies padj = pt-1 / split_ratio — no separate stock-dividend formula.",
+      citation: "S&P §3",
+    },
+    ftse: {
+      rule: "Distinct formula: shares before ÷ shares after",
+      trigger: "always",
+      reason:
+        "FTSE keeps stock dividend distinct from bonus and uses an explicit share-ratio PAF.",
+      citation: "FTSE §3",
+    },
+    stoxx: {
+      rule: "Four sub-types, four PAF formulas (§8.1.5)",
+      trigger: "always",
+      reason:
+        "STOXX splits stock dividends into Ordinary, Treasury Stock, Redeemable Shares, and Shares-of-Another-Company — each with its own PAF; only Treasury Stock changes the divisor.",
+      citation: "STOXX §8.1.5",
+    },
+    solactive: {
+      rule: "Per Equity Index Methodology",
+      trigger: "completion-gate",
+      reason:
+        "Solactive handles stock dividends per its Equity Index Methodology.",
+    },
+    morningstar: {
+      rule: "Absolute share-count ratio — distinct from bonus",
+      trigger: "always",
+      reason:
+        "Morningstar uses pre-event total shares ÷ post-event total shares, distinct from bonus issue.",
+      citation: "Morningstar §3",
+    },
+    vettafi: {
+      rule: "Per index methodology",
+      trigger: "completion-gate",
+      reason: "VettaFi handles stock dividends per the relevant index methodology.",
+    },
+  },
+
+  // ─── §4 Bonus Issue ────────────────────────────────────────────────────────
+  "bonus-issue": {
+    msci: {
+      rule: "Identical across vendors — shares × ratio, no divisor change",
+      trigger: "always",
+      reason:
+        "MSCI applies the bonus ratio to shares; market cap is unchanged so no price or divisor adjustment is needed.",
+      citation: "§4",
+    },
+    sp: {
+      rule: "Identical across vendors — shares × ratio, no divisor change",
+      trigger: "always",
+      reason: "S&P DJI applies the bonus identically to MSCI.",
+      citation: "§4",
+    },
+    ftse: {
+      rule: "Identical across vendors — shares × ratio, no divisor change",
+      trigger: "always",
+      reason: "FTSE Russell applies the bonus identically to MSCI.",
+      citation: "§4",
+    },
+    stoxx: {
+      rule: "Identical across vendors — shares × ratio, no divisor change",
+      trigger: "always",
+      reason: "STOXX applies the bonus identically to MSCI.",
+      citation: "§4",
+    },
+    solactive: {
+      rule: "Identical across vendors — shares × ratio, no divisor change",
+      trigger: "always",
+      reason: "Solactive applies the bonus identically to MSCI.",
+      citation: "§4",
+    },
+    morningstar: {
+      rule: "Identical across vendors — shares × ratio, no divisor change",
+      trigger: "always",
+      reason: "Morningstar applies the bonus identically to MSCI.",
+      citation: "§4",
+    },
+    vettafi: {
+      rule: "Per index methodology",
+      trigger: "completion-gate",
+      reason: "VettaFi has no documented divergence for bonus issues.",
+    },
+  },
+
+  // ─── §5 Stock Split / Consolidation ────────────────────────────────────────
+  "stock-split": {
+    msci: {
+      rule: "padj = pt-1 × A/(A+B); divisor unchanged",
+      trigger: "always",
+      reason: "MSCI applies the standard split PAF; divisor unchanged.",
+      citation: "§5",
+    },
+    sp: {
+      rule: "padj = pt-1 / split_ratio; divisor unchanged",
+      trigger: "always",
+      reason: "S&P DJI applies a ratio PAF; divisor unchanged.",
+      citation: "§5",
+    },
+    ftse: {
+      rule: "Shares before ÷ after; divisor unchanged",
+      trigger: "always",
+      reason: "FTSE applies a share-ratio PAF; divisor unchanged.",
+      citation: "§5",
+    },
+    stoxx: {
+      rule: "Same PAF — but divisor INCREASES (unique)",
+      trigger: "always",
+      reason:
+        "STOXX uniquely adjusts the divisor on a split; for STOXX the index level is held flat while other vendors let it drop with price.",
+      citation: "§5",
+    },
+    solactive: {
+      rule: "Per Equity Index Methodology",
+      trigger: "always",
+      reason: "Solactive applies the split per its Equity Index Methodology.",
+    },
+    morningstar: {
+      rule: "Pre/post share count PAF; divisor unchanged",
+      trigger: "always",
+      reason: "Morningstar applies a share-ratio PAF; divisor unchanged.",
+      citation: "§5",
+    },
+    vettafi: {
+      rule: "Per index methodology",
+      trigger: "always",
+      reason: "VettaFi applies the split per the relevant index methodology.",
+    },
+  },
+
+  // ─── §6 Spin-off / Demerger ────────────────────────────────────────────────
+  "spin-off": {
+    msci: {
+      rule: "Detached security at when-issued price, else zero",
+      trigger: "placeholder-immediate",
+      reason:
+        "MSCI adds the child as a detached security on the distribution date using the when-issued price if available, otherwise zero.",
+      citation: "§6",
+    },
+    sp: {
+      rule: "Zero placeholder, max 20-day grace",
+      trigger: "placeholder-immediate",
+      reason:
+        "S&P DJI adds the child at zero on ex-date and holds the placeholder for up to 20 calendar days before requiring real prices.",
+      citation: "§6",
+    },
+    ftse: {
+      rule: "Estimated price until real trade",
+      trigger: "estimated-price",
+      reason:
+        "FTSE adds the child at an estimated price (parent-difference method) and switches to market price once the child trades.",
+      citation: "§6",
+    },
+    stoxx: {
+      rule: "Waits for first real trade — no placeholder (unique)",
+      trigger: "wait-real-trade",
+      reason:
+        "STOXX is the unique vendor that does NOT use a placeholder — the child is only added once it has a real market price, which is why STOXX projection lines for spin-offs lag others.",
+      citation: "§6",
+    },
+    solactive: {
+      rule: "Adds at 0.00000001 floor on effective date",
+      trigger: "placeholder-immediate",
+      reason:
+        "Solactive uses a 0.00000001 price floor on the effective date and switches to official prices when trading begins; Swedish redemption shares are excluded — only the final form of the security is added.",
+      citation: "§6 (Solactive ECA Guideline v1.4, Oct 2024)",
+    },
+    morningstar: {
+      rule: "Zero placeholder — 40-day grace (60 in India)",
+      trigger: "placeholder-immediate",
+      reason:
+        "Morningstar uses the longest grace window (40 calendar days, 60 in India), which is why MSTAR projection feeds typically show spin-off children before competitors.",
+      citation: "§6",
+    },
+    vettafi: {
+      rule: "Not documented",
+      trigger: "no-coverage",
+      reason: "VettaFi does not document a distinct spin-off path in the sourced methodology.",
+    },
+  },
+
+  // ─── §7 Rights Issue ───────────────────────────────────────────────────────
+  "rights-issue": {
+    msci: {
+      rule: "Adjusts ITM rights only — uses TERP / when-issued price",
+      trigger: "itm-only",
+      reason:
+        "MSCI checks TERP; only in-the-money rights are adjusted. OTM rights are ignored because no rational investor exercises them.",
+      citation: "§7",
+    },
+    sp: {
+      rule: "Adjusts ITM rights only — value-of-rights formula",
+      trigger: "itm-only",
+      reason:
+        "S&P DJI adjusts when subscription price is below market; OTM rights are ignored.",
+      citation: "§7",
+    },
+    ftse: {
+      rule: "Adjusts at any discount — creates 3 nil-paid temp lines",
+      trigger: "always",
+      reason:
+        "FTSE is the most aggressive: it adjusts whenever the rights are at a discount and uniquely creates three temporary lines (nil-paid rights, call dummy, new shares) — so FTSE often shows nil-paid lines that other feeds do not carry.",
+      citation: "§7",
+    },
+    stoxx: {
+      rule: "Standard PAF; HDRI safeguard if >5% mkt-cap impact",
+      trigger: "itm-only",
+      reason:
+        "STOXX applies a standard PAF for ITM rights and triggers HDRI safeguards when dilution exceeds 5% of market cap.",
+      citation: "§7",
+    },
+    solactive: {
+      rule: "Adjusts ITM only; semi-annual review can defer",
+      trigger: "itm-only",
+      reason:
+        "Solactive adjusts only ITM rights; because GPR Global 100 reviews semi-annually, an ITM rights issue between rebalances can miss an entire cycle.",
+      citation: "§7",
+    },
+    morningstar: {
+      rule: "Adjusts ITM rights only — TERP-based",
+      trigger: "itm-only",
+      reason: "Morningstar uses TERP and only adjusts ITM rights.",
+      citation: "§7",
+    },
+    vettafi: {
+      rule: "Not documented",
+      trigger: "no-coverage",
+      reason: "VettaFi does not document a distinct rights-issue path in the sourced methodology.",
+    },
+  },
+
+  // ─── §8 Secondary Offering ─────────────────────────────────────────────────
+  "secondary-offering": {
+    msci: {
+      rule: "Immediate if ≥5% of issued shares; else accumulated to QIR",
+      trigger: "threshold-size",
+      thresholdPct: 5,
+      reason:
+        "MSCI uses a single 5% size threshold — below 5% the change is deferred to the next quarterly index review regardless of dollar value.",
+      citation: "§8",
+    },
+    sp: {
+      rule: "BOTH ≥5% of shares AND ≥USD 150M required",
+      trigger: "threshold-size",
+      thresholdPct: 5,
+      reason:
+        "S&P DJI uses a dual gate: both 5% of issued shares AND a USD 150M floor must be met, so a 5% offering on a small-cap can still slip through to QIR.",
+      citation: "§8",
+    },
+    ftse: {
+      rule: ">1% cumulative per quarter; extraordinary events immediate",
+      trigger: "threshold-size",
+      thresholdPct: 1,
+      reason:
+        "FTSE uses the lowest threshold (1% cumulative per quarter) so it tends to surface secondary offerings earlier than MSCI or S&P, but most are still deferred to QIR.",
+      citation: "§8",
+    },
+    stoxx: {
+      rule: "DIVISOR-only adjustment; ±10% extraordinary triggers immediate",
+      trigger: "threshold-size",
+      thresholdPct: 10,
+      reason:
+        "STOXX is the unique outlier: there is NO PR price adjustment for secondary offerings — only the divisor is adjusted, and only ±10% changes are extraordinary (immediate). Below ±10% goes to the next quarterly review.",
+      citation: "§8",
+    },
+    solactive: {
+      rule: "Case-by-case; ECAs with free float <15% & unconditional → 2 BD notice",
+      trigger: "threshold-float",
+      thresholdPct: 15,
+      noticeDays: 2,
+      reason:
+        "Solactive treats secondaries case-by-case; equity capital actions with free float <15% and an unconditional offer are applied with at least two business days’ notice.",
+      citation: "§8 (Solactive ECA Guideline)",
+    },
+    morningstar: {
+      rule: "Materiality assessment — no fixed % stated",
+      trigger: "completion-gate",
+      reason:
+        "Morningstar makes a materiality call without a published numeric threshold, so its publication timing for the same offering can differ from MSCI/S&P.",
+      citation: "§8",
+    },
+    vettafi: {
+      rule: "Per index methodology",
+      trigger: "completion-gate",
+      reason: "VettaFi has no documented divergence for secondary offerings.",
+    },
+  },
+
+  // ─── §9 Private Placement ──────────────────────────────────────────────────
+  "private-placement": {
+    msci: {
+      rule: "Deferred to QIR unless ≥5% change in shares outstanding",
+      trigger: "threshold-size",
+      thresholdPct: 5,
+      reason:
+        "MSCI defers private placements to QIR unless the change in shares outstanding is ≥5% — so most private placements never appear in the open-constituents projection between reviews.",
+      citation: "§9",
+    },
+    sp: {
+      rule: "Applied on completion if unconditional — no minimum threshold",
+      trigger: "completion-gate",
+      reason:
+        "S&P DJI applies the placement immediately upon unconditional completion regardless of size, so S&P typically shows the line before MSCI.",
+      citation: "§9",
+    },
+    ftse: {
+      rule: "Extraordinary if ≥1% cumulative per quarter",
+      trigger: "threshold-size",
+      thresholdPct: 1,
+      reason:
+        "FTSE applies the same 1% cumulative quarterly trigger it uses for secondaries.",
+      citation: "§9",
+    },
+    stoxx: {
+      rule: "Extraordinary only at ±10% market-cap impact",
+      trigger: "threshold-size",
+      thresholdPct: 10,
+      reason:
+        "STOXX defers all sub-±10% private placements to the quarterly review, so smaller deals will not appear in projections between reviews.",
+      citation: "§9",
+    },
+    solactive: {
+      rule: "Free float <15% & unconditional → 2 BD notice",
+      trigger: "threshold-float",
+      thresholdPct: 15,
+      noticeDays: 2,
+      reason:
+        "Solactive surfaces a private placement when free float falls below 15% and the deal is unconditional, with two business days’ notice.",
+      citation: "§9",
+    },
+    morningstar: {
+      rule: "Materiality assessment — no fixed % stated",
+      trigger: "completion-gate",
+      reason:
+        "Morningstar uses a subjective materiality test — same deal, different timing.",
+      citation: "§9",
+    },
+    vettafi: {
+      rule: "Per index methodology",
+      trigger: "completion-gate",
+      reason: "VettaFi has no documented divergence for private placements.",
+    },
+  },
+
+  // ─── §10 Return of Capital ────────────────────────────────────────────────
+  "return-of-capital": {
+    msci: {
+      rule: "Treated as a special-dividend line",
+      trigger: "always",
+      reason: "MSCI books return of capital as a special-dividend line on ex-date.",
+      citation: "§10",
+    },
+    sp: {
+      rule: "Treated as a special-dividend line",
+      trigger: "always",
+      reason: "S&P DJI books return of capital as a special-dividend line.",
+      citation: "§10",
+    },
+    ftse: {
+      rule: "Direct price adjustment — no separate dividend line (unique)",
+      trigger: "direct-price-adj",
+      reason:
+        "FTSE Russell is the unique vendor that posts return of capital as a direct price adjustment on ex-date rather than a dividend line, so the line will not show in FTSE’s dividend feed even though the price adjustment is identical in effect.",
+      citation: "§10",
+    },
+    stoxx: {
+      rule: "Price adjustment via §8.1.6 formula",
+      trigger: "always",
+      reason:
+        "STOXX uses padj = [pt-1 - capital_return × (1-τ)] × A/B with a share consolidation component.",
+      citation: "STOXX §8.1.6",
+    },
+    solactive: {
+      rule: "Per Equity Index Methodology",
+      trigger: "always",
+      reason: "Solactive applies per its Equity Index Methodology.",
+    },
+    morningstar: {
+      rule: "Special dividend if outside normal cadence",
+      trigger: "always",
+      reason: "Morningstar treats return of capital as a special dividend when outside normal cadence.",
+      citation: "§10",
+    },
+    vettafi: {
+      rule: "Not documented",
+      trigger: "no-coverage",
+      reason: "VettaFi does not document a return-of-capital path.",
+    },
+  },
+
+  // ─── §11 Mergers & Acquisitions ───────────────────────────────────────────
+  merger: {
+    msci: {
+      rule: "Deletes target when deal is unconditional (no fixed %)",
+      trigger: "completion-gate",
+      reason:
+        "MSCI relies on deal certainty rather than a fixed %; the target is removed once the deal is unconditional. Acquirer share-count threshold: 5%/10%/25% by Standard/Small/Micro cap.",
+      citation: "§11",
+    },
+    sp: {
+      rule: "Float <15% OR ≥90% acceptance — either trigger fires",
+      trigger: "threshold-float",
+      thresholdPct: 15,
+      reason:
+        "S&P DJI fires on EITHER Float <15% OR ≥90% acceptance, so the float trigger can delete the target before acceptance reaches 90% — typically the earliest deletion of the major vendors.",
+      citation: "§11",
+    },
+    ftse: {
+      rule: "≥90% held OR Float <5% — either trigger fires",
+      trigger: "threshold-float",
+      thresholdPct: 5,
+      reason:
+        "FTSE Russell deletes when either ≥90% is held or free float falls below 5%; Float <5% is independent of deal completion.",
+      citation: "§11",
+    },
+    stoxx: {
+      rule: "Both ≥85% acquired AND Float <10% required (strictest)",
+      trigger: "threshold-float",
+      thresholdPct: 10,
+      reason:
+        "STOXX is the strictest: BOTH conditions must be met (≥85% acquired AND remaining free float <10%) — if only one is met, deletion is deferred to the next quarterly review.",
+      citation: "STOXX §8.3.1",
+    },
+    solactive: {
+      rule: "Float <15% AND deal unconditional",
+      trigger: "threshold-float",
+      thresholdPct: 15,
+      reason: "Solactive requires both free float <15% and the deal to be unconditional.",
+      citation: "§11",
+    },
+    morningstar: {
+      rule: "Removed on deal completion",
+      trigger: "completion-gate",
+      reason: "Morningstar removes the target on deal completion.",
+      citation: "§11",
+    },
+    vettafi: {
+      rule: "Per index methodology",
+      trigger: "completion-gate",
+      reason: "VettaFi varies by ETF benchmark.",
+    },
+  },
+
+  // ─── §12 Tender Offers ────────────────────────────────────────────────────
+  "tender-offer": {
+    msci: {
+      rule: "Deletes when offer is formally completed (no % threshold)",
+      trigger: "completion-gate",
+      reason:
+        "MSCI waits for formal completion rather than a numeric acceptance %, so MSCI typically appears later than S&P for the same tender.",
+      citation: "§12",
+    },
+    sp: {
+      rule: "Immediate deletion at ≥75% acceptance — no notice",
+      trigger: "threshold-acceptance",
+      thresholdPct: 75,
+      reason:
+        "S&P DJI is the most aggressive: immediate deletion the moment acceptance reaches 75%, with no advance notice.",
+      citation: "§12",
+    },
+    ftse: {
+      rule: "Minimum 2 trading days notice required (unique)",
+      trigger: "notice-required",
+      noticeDays: 2,
+      reason:
+        "FTSE is the only vendor that mandates a two-trading-day notice before deletion, which is why FTSE often lags S&P by exactly two days on the same tender.",
+      citation: "§12",
+    },
+    stoxx: {
+      rule: "Same M&A rule: ≥85% acquired AND Float <10%",
+      trigger: "threshold-acceptance",
+      thresholdPct: 85,
+      reason:
+        "STOXX has no separate tender methodology — it applies the M&A double gate, so a tender at <85% acceptance is deferred to QIR.",
+      citation: "STOXX §8.3.1.1",
+    },
+    solactive: {
+      rule: "Float <15% AND offer unconditional",
+      trigger: "threshold-float",
+      thresholdPct: 15,
+      reason: "Solactive applies the same Float <15% + unconditional rule as M&A.",
+      citation: "§12",
+    },
+    morningstar: {
+      rule: "Deletes on offer completion (no % threshold)",
+      trigger: "completion-gate",
+      reason: "Morningstar deletes when the tender offer formally completes.",
+      citation: "§12",
+    },
+    vettafi: {
+      rule: "Per index methodology",
+      trigger: "completion-gate",
+      reason: "VettaFi varies by ETF benchmark.",
+    },
+  },
+
+  // ─── §13 Bankruptcy / Delisting ───────────────────────────────────────────
+  bankruptcy: {
+    msci: {
+      rule: "Immediate announcement, 2-day implementation; last traded or 0.0000001 if none",
+      trigger: "always",
+      reason:
+        "MSCI announces immediately and implements in two days, removing at last traded price or 0.0000001 if none exists.",
+      citation: "§13",
+    },
+    sp: {
+      rule: "Removed at last traded / M&A terms on delisting",
+      trigger: "always",
+      reason: "S&P DJI removes at market price or M&A terms upon delisting / bankruptcy.",
+      citation: "§13",
+    },
+    ftse: {
+      rule: "Removed on effective date at last traded or M&A terms",
+      trigger: "always",
+      reason: "FTSE Russell removes on the effective date.",
+      citation: "§13",
+    },
+    stoxx: {
+      rule: "10 consecutive suspension days OR bankruptcy filing → 2-day implementation",
+      trigger: "always",
+      reason:
+        "STOXX deletes after 10 consecutive suspension days or a bankruptcy filing; the floor price is 0.0000001, not zero, to avoid division-by-zero in index math.",
+      citation: "§13",
+    },
+    solactive: {
+      rule: "Last available price; if none, 0.00000001 floor",
+      trigger: "always",
+      reason: "Solactive uses the last available price or its 0.00000001 floor.",
+      citation: "§13",
+    },
+    morningstar: {
+      rule: "Removed at market price upon event",
+      trigger: "always",
+      reason: "Morningstar removes at market price upon the event.",
+      citation: "§13",
+    },
+    vettafi: {
+      rule: "Not documented",
+      trigger: "no-coverage",
+      reason: "VettaFi does not document a distinct delisting path in the sourced methodology.",
+    },
+  },
+};
+
+/** Look up the rule for a (vendor, event) pair, with `undefined` if missing. */
+export function getVendorRule(
+  event: CanonicalEventId,
+  vendor: VendorId,
+): VendorRule | undefined {
+  return VENDOR_RULES[event]?.[vendor];
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Two complaints from the latest review:

1. **The list of event types in the simulator does not tally with the documentation.** The Vendor Reference (`/vendors/`) and `SOURCES/index-vendor-methodology.md` describe the canonical **13 ISO CAEV event types** with **5 voluntary** (Special Cash Dividend, Rights Issue, Secondary Offering, Private Placement, Tender Offers) and **8 mandatory**. The simulator was still on a coarse 9-family local taxonomy with only **2 voluntary** entries (`rights`, `tender`).
2. **Vendor thresholds were never reflected in the result.** Hypotheses were generic ("VOLUNTARY EVENT — PARTICIPATION OPEN") with no vendor names, no thresholds, and no concrete reasoning for why the divergence occurred.

## What changed

### Single source of truth for the event taxonomy
- `src/lib/simulator/types.ts` — `EventFamily` is now `CanonicalEventId` from `@/lib/event-taxonomy`. Removed the redundant `dividendFlavor` field; cash-dividend and special-dividend are now their own canonical events.
- `src/lib/simulator/taxonomy.ts` — `MANDATORY_FAMILIES`, `VOLUNTARY_FAMILIES`, `FAMILY_TO_CLASS`, and `humanFamily()` are derived from `CANONICAL_EVENTS`. Voluntary surface is now: **Special Cash Dividend · Rights Issue · Secondary Offering · Private Placement · Tender Offers**.

### New vendor rule table
- `src/lib/simulator/vendor-rules.ts` (new) — structured per `(event × vendor)` rules taken straight from `SOURCES/index-vendor-methodology.md` §1–§13: trigger type, numeric threshold (size %, free-float %, acceptance %), advance-notice days, plain-language reason, source citation.

### Engine produces concrete, vendor-named verdicts
- `src/lib/simulator/simulator-engine.ts` — `runSimulator` now evaluates **every selected vendor** against its documented rule and emits a hypothesis per vendor with status (`publish` / `suppress` / `indeterminate`) and the rule that drove it. Examples:
  - *S&P DJI: acceptance ≈ 80% meets the 75% trigger — this vendor would already publish the deletion line.*
  - *FTSE Russell: requires 2 trading days of advance notice — even when the threshold is met, the deletion line lags peers by that many days.*
  - *STOXX: this vendor does NOT use a placeholder — the child is only added once it has a real market price, which is why STOXX projection lines for spin-offs lag others.*
- New `verdict` field on `SimulatorResult` — one definite sentence classifying the gap as a **true data gap**, **methodology divergence (not a data gap)**, or **expected silence**, with vendors named.

### UI updated to match
- `src/components/projection-gap-simulator.tsx` — Step 2 lists all 13 canonical events grouped by category (`Equity Income` / `Corporate Structure` / `Equity Offerings` / `M&A`), so all 5 voluntary types are now selectable. Sub-detail panels updated for the new ids; PR/TR/NTR prompt now applies to cash-dividend and special-dividend. Result step renders the new `verdict` block and shows the source citation on every per-vendor card.

Rules version bumped `1.1.1` → `2.0.0`.

## Verification

- `npx tsc --noEmit` — clean
- `npm run lint` — clean
- `npm run build` — clean (Next.js 16, all 9 routes generated)
- `assertVendorEventsMatchCanonical` (dev-only) still passes for `/vendors/` so the simulator, decision tree, and Vendor Reference remain in lockstep.
- Homepage `buildDecisionTreeStep2()` already pulls from `eventNamesSentence("voluntary")`, so the decision tree under "Voluntary" now lists all 5 types automatically.

## Files
- `src/lib/simulator/types.ts`
- `src/lib/simulator/taxonomy.ts`
- `src/lib/simulator/vendor-rules.ts` (new)
- `src/lib/simulator/simulator-engine.ts`
- `src/components/projection-gap-simulator.tsx`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5cc05f8d-c37c-4447-8562-d2c1cf40aa06"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5cc05f8d-c37c-4447-8562-d2c1cf40aa06"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

