### PR TITLE
Simulator UX polish + global investor snapshot

### DIFF
--- a/src/app/api/investors/search/route.ts
+++ b/src/app/api/investors/search/route.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from "next/server";
+
+import { searchSymbols } from "@/lib/investors/yahoo-finance";
+
+const CACHE_CONTROL = "public, s-maxage=600, stale-while-revalidate=1200";
+const TTL_MS = 10 * 60 * 1000;
+const cache = new Map<string, { at: number; body: unknown }>();
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const q = (searchParams.get("q") ?? "").trim();
+
+  if (q.length < 1) {
+    return NextResponse.json({ results: [] }, { headers: { "Cache-Control": CACHE_CONTROL } });
+  }
+  if (q.length > 40) {
+    return NextResponse.json(
+      { error: "Query too long", code: "TOO_LONG" },
+      { status: 400 },
+    );
+  }
+
+  const key = q.toLowerCase();
+  const now = Date.now();
+  const hit = cache.get(key);
+  if (hit && now - hit.at < TTL_MS) {
+    return NextResponse.json(hit.body, {
+      headers: { "Cache-Control": CACHE_CONTROL },
+    });
+  }
+
+  const results = await searchSymbols(q, 10);
+  const body = { results };
+  cache.set(key, { at: now, body });
+
+  return NextResponse.json(body, {
+    headers: { "Cache-Control": CACHE_CONTROL },
+  });
+}

--- a/src/app/investors/page.tsx
+++ b/src/app/investors/page.tsx
@@ -14,6 +14,16 @@ import { UpcomingEventsCard } from "@/components/investors/upcoming-events-card"
 import { InvestorDataWarnings } from "@/components/investors/investor-data-warnings";
 import type { InvestorTickerResponse } from "@/lib/investors/types";
 
+const EXAMPLE_TICKERS: Array<{ symbol: string; label: string }> = [
+  { symbol: "AAPL", label: "AAPL · Apple" },
+  { symbol: "MSFT", label: "MSFT · Microsoft" },
+  { symbol: "0005.HK", label: "0005.HK · HSBC" },
+  { symbol: "7203.T", label: "7203.T · Toyota" },
+  { symbol: "VOD.L", label: "VOD.L · Vodafone" },
+  { symbol: "SAP.DE", label: "SAP.DE · SAP" },
+  { symbol: "BHP.AX", label: "BHP.AX · BHP" },
+];
+
 export default function InvestorsPage() {
   const reduceMotion = useReducedMotion();
   const [input, setInput] = useState("");
@@ -67,9 +77,11 @@ export default function InvestorsPage() {
           </div>
           <h1 className="mb-3 text-3xl font-semibold tracking-tight">Investor intelligence</h1>
           <p className="max-w-prose text-sm text-muted-foreground">
-            Enter a US-listed symbol for a quick read on recent dividends, splits, and
-            calendar hints. Data is third-party and delayed — not advice, not a substitute
-            for your broker or official notices. For{" "}
+            Search any company or symbol covered by Yahoo Finance — US, Europe,
+            Hong Kong, Japan, Australia, emerging markets, ADRs, and ETFs. Type a
+            name (<em>Apple</em>, <em>Toyota</em>, <em>HSBC</em>) or a symbol with
+            suffix (<code>0005.HK</code>, <code>7203.T</code>, <code>VOD.L</code>).
+            Data is third-party and delayed — not advice. For{" "}
             <Link href="/vendors/" className="text-primary underline-offset-4 hover:underline">
               index vendor methodology
             </Link>
@@ -83,17 +95,28 @@ export default function InvestorsPage() {
           <InvestorSearchBar
             value={input}
             onChange={setInput}
-            onSubmit={() => runSearch(input)}
+            onSubmit={(symbol) => {
+              setInput(symbol);
+              void runSearch(symbol);
+            }}
             loading={loading}
           />
-          <p className="mt-4 text-xs text-muted-foreground">
-            Try <button type="button" className="text-primary hover:underline" onClick={() => { setInput("AAPL"); void runSearch("AAPL"); }}>AAPL</button>
-            {", "}
-            <button type="button" className="text-primary hover:underline" onClick={() => { setInput("MSFT"); void runSearch("MSFT"); }}>MSFT</button>
-            {", or "}
-            <button type="button" className="text-primary hover:underline" onClick={() => { setInput("JPM"); void runSearch("JPM"); }}>JPM</button>
-            .
-          </p>
+          <div className="mt-4 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+            <span>Try:</span>
+            {EXAMPLE_TICKERS.map((t) => (
+              <button
+                key={t.symbol}
+                type="button"
+                className="rounded-full border border-border bg-background/60 px-2.5 py-1 font-medium text-foreground transition-colors hover:border-primary/40 hover:bg-muted/40"
+                onClick={() => {
+                  setInput(t.symbol);
+                  void runSearch(t.symbol);
+                }}
+              >
+                {t.label}
+              </button>
+            ))}
+          </div>
         </SurfaceSection>
 
         {error && (
@@ -125,6 +148,9 @@ export default function InvestorsPage() {
                 dividends={data?.dividends ?? []}
                 dividendRate={data?.metrics?.dividendRate}
                 dividendYield={data?.metrics?.dividendYield}
+                payoutRatio={data?.metrics?.payoutRatio}
+                fiveYearAvgDividendYield={data?.metrics?.fiveYearAvgDividendYield}
+                currency={data?.quote?.currency}
                 loading={loading}
               />
               <div className="grid gap-6 sm:grid-cols-2">
@@ -138,7 +164,10 @@ export default function InvestorsPage() {
         <footer className="mt-12 border-t border-border pt-8 text-xs text-muted-foreground">
           <p className="max-w-prose leading-relaxed">
             Quotes and events are aggregated from public market data feeds and may be
-            incomplete or delayed. This page is for orientation only.
+            incomplete or delayed. Coverage depends on Yahoo Finance — most global
+            exchanges are supported via suffixes (<code>.HK</code>, <code>.T</code>,
+            <code>.L</code>, <code>.DE</code>, <code>.TO</code>, <code>.AX</code>,
+            …). This page is for orientation only.
           </p>
         </footer>
       </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -218,41 +218,6 @@ export default function Home() {
             </div>
             <div className="flex min-w-0 w-full max-w-full flex-col gap-6 xl:self-start">
               <ProjectionGapSimulator />
-              <div className="rounded-xl border border-border bg-card/60 px-4 py-4 sm:px-5">
-                <p className="mb-3 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                  Related tools
-                </p>
-                <div className="flex flex-col gap-2 text-sm sm:flex-row sm:flex-wrap sm:items-center sm:gap-x-4 sm:gap-y-2">
-                  <Link
-                    href="/vendors/"
-                    className="inline-flex items-center gap-2 text-muted-foreground transition-colors hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background rounded-md outline-none"
-                  >
-                    <BookOpenIcon className="h-4 w-4 shrink-0" aria-hidden />
-                    Vendor thresholds
-                  </Link>
-                  <span className="hidden text-border sm:inline" aria-hidden>
-                    ·
-                  </span>
-                  <Link
-                    href="/investors/"
-                    className="inline-flex items-center gap-2 text-muted-foreground transition-colors hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background rounded-md outline-none"
-                  >
-                    <LineChartIcon className="h-4 w-4 shrink-0" aria-hidden />
-                    Investor snapshot
-                  </Link>
-                  <span className="hidden text-border sm:inline" aria-hidden>
-                    ·
-                  </span>
-                  <button
-                    type="button"
-                    onClick={() => scrollToId("decision-tree")}
-                    className="inline-flex min-h-11 items-center gap-2 rounded-md text-left text-muted-foreground transition-colors hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background outline-none sm:min-h-0"
-                  >
-                    <CompassIcon className="h-4 w-4 shrink-0" aria-hidden />
-                    Find divergence point
-                  </button>
-                </div>
-              </div>
             </div>
           </div>
         </div>
@@ -499,7 +464,7 @@ export default function Home() {
             <GlobeIcon className="mb-3 h-5 w-5 text-primary" />
             <div className="mb-1 text-sm font-semibold">Investor snapshot</div>
             <p className="text-xs text-muted-foreground">
-              Dividends, splits, and calendar hints by ticker (delayed data)
+              Global dividends, splits, calendar, and fundamentals — search any Yahoo-covered symbol or company
             </p>
           </Link>
           <div className="rounded-2xl border border-border bg-card p-5">

--- a/src/components/investors/dividend-summary-card.tsx
+++ b/src/components/investors/dividend-summary-card.tsx
@@ -1,13 +1,16 @@
 "use client";
 
 import type { InvestorDividendRow } from "@/lib/investors/types";
-import { dividendTrend, formatUsd } from "@/lib/investors/format";
+import { dividendTrend, formatCurrency } from "@/lib/investors/format";
 import { GlossaryTerm } from "@/components/ui/glossary-term";
 
 interface Props {
   dividends: InvestorDividendRow[];
   dividendRate?: number;
   dividendYield?: number;
+  payoutRatio?: number;
+  fiveYearAvgDividendYield?: number;
+  currency?: string;
   loading?: boolean;
 }
 
@@ -27,53 +30,113 @@ export function DividendSummaryCard({
   dividends,
   dividendRate,
   dividendYield,
+  payoutRatio,
+  fiveYearAvgDividendYield,
+  currency,
   loading,
 }: Props) {
   if (loading) return <SkeletonCard />;
+
+  const hasAny =
+    dividends.length > 0 ||
+    dividendRate != null ||
+    dividendYield != null ||
+    payoutRatio != null ||
+    fiveYearAvgDividendYield != null;
 
   const trend = dividendTrend(dividends);
   const trendLabel =
     trend === "up" ? "↑" : trend === "down" ? "↓" : trend === "flat" ? "—" : "—";
 
+  const recent = dividends.slice(0, 5);
+
   return (
     <div className="rounded-xl border border-border bg-card/80 p-6">
-      <h3 className="mb-4 text-sm font-semibold text-foreground">Dividend history</h3>
-      {dividends.length === 0 ? (
-        <p className="text-sm text-muted-foreground">No recent dividends in range.</p>
+      <h3 className="mb-4 text-sm font-semibold text-foreground">Dividend summary</h3>
+
+      {!hasAny ? (
+        <p className="text-sm text-muted-foreground">
+          No dividend information reported for this security.
+        </p>
       ) : (
         <>
-          <p className="mb-3 text-sm tabular-nums text-foreground">
-            {dividends
-              .map((d) => formatUsd(d.amount))
-              .join(" → ")}
-            <span className="ml-2 text-muted-foreground">({trendLabel} cadence)</span>
-          </p>
-          <div className="flex flex-wrap gap-4 text-sm tabular-nums">
+          {recent.length > 0 && (
+            <div className="mb-4 space-y-2">
+              <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                Recent distributions (oldest → newest)
+              </p>
+              <p className="text-sm tabular-nums text-foreground">
+                {[...recent]
+                  .reverse()
+                  .map((d) => formatCurrency(d.amount, currency))
+                  .join(" → ")}
+                <span className="ml-2 text-muted-foreground">({trendLabel} cadence)</span>
+              </p>
+            </div>
+          )}
+
+          <dl className="grid grid-cols-2 gap-x-4 gap-y-3 text-sm">
             {dividendRate != null && (
-              <span className="text-muted-foreground">
-                <GlossaryTerm
-                  term="Dividend rate"
-                  definition="Annualized cash dividend per share, when reported by the data source."
-                >
-                  Rate
-                </GlossaryTerm>
-                :{" "}
-                <span className="font-medium text-foreground">{formatUsd(dividendRate)}/yr</span>
-              </span>
+              <div>
+                <dt className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+                  <GlossaryTerm
+                    term="Annual dividend rate"
+                    definition="Annualized cash dividend per share expected over the next 12 months, as reported by the data source."
+                  >
+                    Annual rate
+                  </GlossaryTerm>
+                </dt>
+                <dd className="tabular-nums font-medium text-foreground">
+                  {formatCurrency(dividendRate, currency)}
+                </dd>
+              </div>
             )}
             {dividendYield != null && (
-              <span className="text-muted-foreground">
-                <GlossaryTerm
-                  term="Dividend yield"
-                  definition="Annual dividend divided by the latest price, as a percentage. Delayed snapshot."
-                >
-                  Yield
-                </GlossaryTerm>
-                :{" "}
-                <span className="font-medium text-foreground">{dividendYield.toFixed(2)}%</span>
-              </span>
+              <div>
+                <dt className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+                  <GlossaryTerm
+                    term="Dividend yield"
+                    definition="Annual dividend divided by the latest price, as a percentage. Delayed snapshot — value can swing with price."
+                  >
+                    Yield
+                  </GlossaryTerm>
+                </dt>
+                <dd className="tabular-nums font-medium text-foreground">
+                  {dividendYield.toFixed(2)}%
+                </dd>
+              </div>
             )}
-          </div>
+            {fiveYearAvgDividendYield != null && (
+              <div>
+                <dt className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+                  <GlossaryTerm
+                    term="5-yr average yield"
+                    definition="Trailing five-year average of the dividend yield. Useful for spotting how today's yield compares to its own history."
+                  >
+                    5-yr avg yield
+                  </GlossaryTerm>
+                </dt>
+                <dd className="tabular-nums font-medium text-foreground">
+                  {fiveYearAvgDividendYield.toFixed(2)}%
+                </dd>
+              </div>
+            )}
+            {payoutRatio != null && (
+              <div>
+                <dt className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+                  <GlossaryTerm
+                    term="Payout ratio"
+                    definition="Dividends paid as a percentage of earnings. Above 100% means the company is paying more than it currently earns."
+                  >
+                    Payout ratio
+                  </GlossaryTerm>
+                </dt>
+                <dd className="tabular-nums font-medium text-foreground">
+                  {payoutRatio.toFixed(1)}%
+                </dd>
+              </div>
+            )}
+          </dl>
         </>
       )}
     </div>

--- a/src/components/investors/investor-quote-strip.tsx
+++ b/src/components/investors/investor-quote-strip.tsx
@@ -1,7 +1,12 @@
 "use client";
 
 import type { InvestorQuote } from "@/lib/investors/types";
-import { formatPct, formatUsd } from "@/lib/investors/format";
+import {
+  formatCompact,
+  formatCurrency,
+  formatInteger,
+  formatPct,
+} from "@/lib/investors/format";
 
 interface Props {
   ticker: string;
@@ -11,9 +16,44 @@ interface Props {
 
 function Skeleton() {
   return (
-    <div className="animate-pulse rounded-xl border border-border bg-card/60 p-4">
-      <div className="mb-2 h-6 w-32 rounded bg-muted" />
-      <div className="h-4 w-48 rounded bg-muted/80" />
+    <div className="animate-pulse rounded-xl border border-border bg-card/60 p-5">
+      <div className="mb-2 h-6 w-40 rounded bg-muted" />
+      <div className="mb-4 h-4 w-56 rounded bg-muted/80" />
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+        {Array.from({ length: 8 }).map((_, i) => (
+          <div key={i} className="space-y-1.5">
+            <div className="h-3 w-16 rounded bg-muted/70" />
+            <div className="h-4 w-20 rounded bg-muted" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function Stat({
+  label,
+  value,
+  tone = "default",
+}: {
+  label: string;
+  value?: string | null;
+  tone?: "default" | "positive" | "negative";
+}) {
+  const toneClass =
+    tone === "positive"
+      ? "text-emerald-500"
+      : tone === "negative"
+        ? "text-destructive"
+        : "text-foreground";
+  return (
+    <div className="min-w-0">
+      <div className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+        {label}
+      </div>
+      <div className={`truncate text-sm font-medium tabular-nums ${toneClass}`}>
+        {value ?? "—"}
+      </div>
     </div>
   );
 }
@@ -21,42 +61,154 @@ function Skeleton() {
 export function InvestorQuoteStrip({ ticker, quote, loading }: Props) {
   if (loading) return <Skeleton />;
 
+  const currency = quote?.currency;
+  const price = quote?.price != null ? formatCurrency(quote.price, currency) : undefined;
+  const prevClose =
+    quote?.previousClose != null
+      ? formatCurrency(quote.previousClose, currency)
+      : undefined;
+  const dayRange =
+    quote?.dayLow != null && quote?.dayHigh != null
+      ? `${formatCurrency(quote.dayLow, currency)} – ${formatCurrency(quote.dayHigh, currency)}`
+      : undefined;
+  const yearRange =
+    quote?.yearLow != null && quote?.yearHigh != null
+      ? `${formatCurrency(quote.yearLow, currency)} – ${formatCurrency(quote.yearHigh, currency)}`
+      : undefined;
+  const marketCap = formatCompact(quote?.marketCap, currency);
+  const volume = formatInteger(quote?.volume);
+  const avgVolume = formatInteger(quote?.avgVolume);
+  const pe =
+    quote?.peTrailing != null && Number.isFinite(quote.peTrailing)
+      ? quote.peTrailing.toFixed(2)
+      : undefined;
+  const beta =
+    quote?.beta != null && Number.isFinite(quote.beta)
+      ? quote.beta.toFixed(2)
+      : undefined;
+  const eps =
+    quote?.epsTrailing != null && Number.isFinite(quote.epsTrailing)
+      ? formatCurrency(quote.epsTrailing, currency)
+      : undefined;
+
+  const tone =
+    quote?.changePct != null
+      ? quote.changePct > 0
+        ? "positive"
+        : quote.changePct < 0
+          ? "negative"
+          : "default"
+      : "default";
+
   return (
-    <div className="rounded-xl border border-border bg-card/80 p-4">
-      <div className="flex flex-wrap items-baseline gap-2 gap-y-1">
-        <span className="text-2xl font-semibold tracking-tight text-foreground">{ticker}</span>
+    <div className="rounded-xl border border-border bg-card/80 p-5">
+      <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
+        <span className="text-2xl font-semibold tracking-tight text-foreground">
+          {ticker}
+        </span>
         {quote?.name && (
-          <span className="text-sm text-muted-foreground">· {quote.name}</span>
+          <span className="min-w-0 truncate text-sm text-muted-foreground">
+            {quote.name}
+          </span>
         )}
       </div>
-      <div className="mt-2 flex flex-wrap items-center gap-2 text-sm tabular-nums">
-        {quote?.price != null && (
-          <span className="font-medium text-foreground">{formatUsd(quote.price)}</span>
+
+      <div className="mt-2 flex flex-wrap items-center gap-2 text-sm">
+        {price && (
+          <span className="text-2xl font-semibold tabular-nums text-foreground">
+            {price}
+          </span>
+        )}
+        {quote?.changeAbs != null && (
+          <span
+            className={
+              "tabular-nums " +
+              (tone === "positive"
+                ? "text-emerald-500"
+                : tone === "negative"
+                  ? "text-destructive"
+                  : "text-muted-foreground")
+            }
+          >
+            {quote.changeAbs > 0 ? "+" : ""}
+            {formatCurrency(quote.changeAbs, currency)}
+          </span>
         )}
         {quote?.changePct != null && (
           <span
             className={
-              quote.changePct > 0
+              "tabular-nums " +
+              (tone === "positive"
                 ? "text-emerald-500"
-                : quote.changePct < 0
+                : tone === "negative"
                   ? "text-destructive"
-                  : "text-muted-foreground"
+                  : "text-muted-foreground")
             }
           >
-            {formatPct(quote.changePct)}
+            ({formatPct(quote.changePct)})
           </span>
         )}
-        {quote?.sector && (
-          <span className="rounded-full border border-border bg-muted/40 px-2 py-0.5 text-xs font-medium text-muted-foreground">
-            {quote.sector}
+        {currency && (
+          <span className="rounded-full border border-border bg-muted/40 px-2 py-0.5 text-[11px] font-medium text-muted-foreground">
+            {currency}
           </span>
         )}
-        {quote?.exchange && (
-          <span className="rounded-full border border-border bg-muted/40 px-2 py-0.5 text-xs text-muted-foreground">
-            {quote.exchange}
+        {quote?.marketState && (
+          <span className="rounded-full border border-border bg-muted/40 px-2 py-0.5 text-[11px] uppercase tracking-wide text-muted-foreground">
+            {quote.marketState.toLowerCase()}
           </span>
         )}
       </div>
+
+      <div className="mt-3 flex flex-wrap gap-1.5">
+        {quote?.exchange && (
+          <span className="rounded-full border border-border bg-muted/40 px-2 py-0.5 text-[11px] text-muted-foreground">
+            {quote.exchange}
+          </span>
+        )}
+        {quote?.quoteType && (
+          <span className="rounded-full border border-border bg-muted/40 px-2 py-0.5 text-[11px] uppercase tracking-wide text-muted-foreground">
+            {quote.quoteType}
+          </span>
+        )}
+        {quote?.country && (
+          <span className="rounded-full border border-border bg-muted/40 px-2 py-0.5 text-[11px] text-muted-foreground">
+            {quote.country}
+          </span>
+        )}
+        {quote?.sector && (
+          <span className="rounded-full border border-border bg-muted/40 px-2 py-0.5 text-[11px] text-muted-foreground">
+            {quote.sector}
+          </span>
+        )}
+        {quote?.industry && (
+          <span className="rounded-full border border-border bg-muted/40 px-2 py-0.5 text-[11px] text-muted-foreground">
+            {quote.industry}
+          </span>
+        )}
+      </div>
+
+      {(prevClose ||
+        dayRange ||
+        yearRange ||
+        marketCap ||
+        volume ||
+        avgVolume ||
+        pe ||
+        beta ||
+        eps) && (
+        <div className="mt-4 grid grid-cols-2 gap-x-4 gap-y-3 border-t border-border/60 pt-4 sm:grid-cols-3 md:grid-cols-4">
+          <Stat label="Prev close" value={prevClose} />
+          <Stat label="Day range" value={dayRange} />
+          <Stat label="52-wk range" value={yearRange} />
+          <Stat label="Market cap" value={marketCap} />
+          <Stat label="Volume" value={volume} />
+          <Stat label="Avg volume" value={avgVolume} />
+          <Stat label="P/E (ttm)" value={pe} />
+          <Stat label="EPS (ttm)" value={eps} />
+          <Stat label="Beta" value={beta} />
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/investors/investor-search-bar.tsx
+++ b/src/components/investors/investor-search-bar.tsx
@@ -1,9 +1,14 @@
 "use client";
 
+import { useEffect, useId, useMemo, useRef, useState } from "react";
+import { SearchIcon } from "lucide-react";
+
+import type { InvestorSearchResult } from "@/lib/investors/types";
+
 interface Props {
   value: string;
   onChange: (v: string) => void;
-  onSubmit: () => void;
+  onSubmit: (symbol: string) => void;
   loading: boolean;
   disabled?: boolean;
 }
@@ -15,38 +20,199 @@ export function InvestorSearchBar({
   loading,
   disabled,
 }: Props) {
-  return (
-    <form
-      className="flex flex-col gap-3 sm:flex-row sm:items-end"
-      onSubmit={(e) => {
+  const listboxId = useId();
+  const [results, setResults] = useState<InvestorSearchResult[]>([]);
+  const [open, setOpen] = useState(false);
+  const [highlight, setHighlight] = useState(-1);
+  const [searching, setSearching] = useState(false);
+  const abortRef = useRef<AbortController | null>(null);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  const trimmed = useMemo(() => value.trim(), [value]);
+
+  useEffect(() => {
+    if (trimmed.length < 1) {
+      return;
+    }
+    const t = window.setTimeout(async () => {
+      abortRef.current?.abort();
+      const ctrl = new AbortController();
+      abortRef.current = ctrl;
+      setSearching(true);
+      try {
+        const res = await fetch(
+          `/api/investors/search/?q=${encodeURIComponent(trimmed)}`,
+          { signal: ctrl.signal, cache: "no-store" },
+        );
+        if (!res.ok) throw new Error("search failed");
+        const json = (await res.json()) as { results: InvestorSearchResult[] };
+        setResults(json.results ?? []);
+        setOpen(true);
+        setHighlight((json.results?.length ?? 0) > 0 ? 0 : -1);
+      } catch {
+        // abort or network error — silent
+      } finally {
+        setSearching(false);
+      }
+    }, 200);
+
+    return () => window.clearTimeout(t);
+  }, [trimmed]);
+
+  function handleChange(next: string) {
+    onChange(next);
+    setHighlight(-1);
+    if (next.trim().length < 1) {
+      setResults([]);
+      setOpen(false);
+    }
+  }
+
+  useEffect(() => {
+    function onClickAway(e: MouseEvent) {
+      if (!containerRef.current) return;
+      if (!containerRef.current.contains(e.target as Node)) setOpen(false);
+    }
+    window.addEventListener("mousedown", onClickAway);
+    return () => window.removeEventListener("mousedown", onClickAway);
+  }, []);
+
+  function pick(result: InvestorSearchResult) {
+    onChange(result.symbol);
+    setOpen(false);
+    onSubmit(result.symbol);
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (!open || results.length === 0) {
+      if (e.key === "Enter") {
         e.preventDefault();
-        onSubmit();
-      }}
-    >
-      <div className="min-w-0 flex-1">
-        <label htmlFor="investor-ticker" className="mb-2 block text-sm font-medium text-foreground">
-          Ticker symbol
-        </label>
-        <input
-          id="investor-ticker"
-          name="ticker"
-          type="text"
-          inputMode="text"
-          autoComplete="off"
-          placeholder="e.g. AAPL, MSFT, BRK-B"
-          value={value}
-          onChange={(e) => onChange(e.target.value)}
-          disabled={disabled || loading}
-          className="h-12 w-full rounded-xl border border-border bg-background px-4 text-base text-foreground outline-none ring-primary/40 transition-shadow placeholder:text-muted-foreground focus-visible:ring-2 disabled:opacity-50"
-        />
-      </div>
-      <button
-        type="submit"
-        disabled={disabled || loading || !value.trim()}
-        className="inline-flex h-12 min-w-[120px] shrink-0 items-center justify-center rounded-xl bg-primary px-6 text-sm font-semibold text-primary-foreground transition-colors hover:bg-primary/90 disabled:pointer-events-none disabled:opacity-40"
+        onSubmit(trimmed);
+      }
+      return;
+    }
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setHighlight((h) => (h + 1) % results.length);
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setHighlight((h) => (h - 1 + results.length) % results.length);
+    } else if (e.key === "Enter") {
+      e.preventDefault();
+      const r = results[highlight] ?? results[0];
+      if (r) pick(r);
+      else onSubmit(trimmed);
+    } else if (e.key === "Escape") {
+      setOpen(false);
+    }
+  }
+
+  return (
+    <div ref={containerRef} className="relative">
+      <form
+        className="flex flex-col gap-3 sm:flex-row sm:items-end"
+        onSubmit={(e) => {
+          e.preventDefault();
+          const r = results[highlight];
+          if (open && r) pick(r);
+          else onSubmit(trimmed);
+        }}
       >
-        {loading ? "Loading…" : "Search"}
-      </button>
-    </form>
+        <div className="min-w-0 flex-1">
+          <label htmlFor="investor-ticker" className="mb-2 block text-sm font-medium text-foreground">
+            Search a ticker or company
+          </label>
+          <div className="relative">
+            <SearchIcon
+              className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground"
+              aria-hidden
+            />
+            <input
+              id="investor-ticker"
+              name="ticker"
+              type="text"
+              inputMode="text"
+              autoComplete="off"
+              spellCheck={false}
+              placeholder="e.g. Apple, AAPL, 0005.HK, 7203.T, VOD.L"
+              value={value}
+              onChange={(e) => handleChange(e.target.value)}
+              onFocus={() => {
+                if (results.length > 0) setOpen(true);
+              }}
+              onKeyDown={handleKeyDown}
+              disabled={disabled || loading}
+              role="combobox"
+              aria-autocomplete="list"
+              aria-expanded={open && results.length > 0}
+              aria-controls={listboxId}
+              aria-haspopup="listbox"
+              aria-activedescendant={
+                open && highlight >= 0 && results[highlight]
+                  ? `${listboxId}-opt-${highlight}`
+                  : undefined
+              }
+              className="h-12 w-full rounded-xl border border-border bg-background pl-9 pr-4 text-base text-foreground outline-none ring-primary/40 transition-shadow placeholder:text-muted-foreground focus-visible:ring-2 disabled:opacity-50"
+            />
+          </div>
+        </div>
+        <button
+          type="submit"
+          disabled={disabled || loading || !trimmed}
+          className="inline-flex h-12 min-w-[120px] shrink-0 items-center justify-center rounded-xl bg-primary px-6 text-sm font-semibold text-primary-foreground transition-colors hover:bg-primary/90 disabled:pointer-events-none disabled:opacity-40"
+        >
+          {loading ? "Loading…" : "Search"}
+        </button>
+      </form>
+
+      {open && (results.length > 0 || searching) && (
+        <ul
+          id={listboxId}
+          role="listbox"
+          className="absolute left-0 right-0 sm:right-[128px] top-full z-30 mt-2 max-h-80 overflow-auto rounded-xl border border-border bg-popover p-1 shadow-xl"
+        >
+          {searching && results.length === 0 && (
+            <li className="px-3 py-2 text-sm text-muted-foreground">Searching…</li>
+          )}
+          {results.map((r, i) => (
+            <li
+              id={`${listboxId}-opt-${i}`}
+              key={`${r.symbol}-${i}`}
+              role="option"
+              aria-selected={highlight === i}
+              onMouseEnter={() => setHighlight(i)}
+              onMouseDown={(e) => e.preventDefault()}
+              onClick={() => pick(r)}
+              className={
+                "cursor-pointer rounded-lg px-3 py-2 text-sm transition-colors " +
+                (highlight === i
+                  ? "bg-muted text-foreground"
+                  : "text-foreground hover:bg-muted/70")
+              }
+            >
+              <div className="flex flex-wrap items-baseline justify-between gap-x-3 gap-y-0.5">
+                <span className="font-mono text-sm font-semibold">{r.symbol}</span>
+                {r.quoteType && (
+                  <span className="text-[11px] uppercase tracking-wide text-muted-foreground">
+                    {r.quoteType}
+                  </span>
+                )}
+              </div>
+              {r.name && (
+                <div className="truncate text-xs text-muted-foreground">
+                  {r.name}
+                </div>
+              )}
+              {(r.exchange || r.sector) && (
+                <div className="mt-0.5 flex flex-wrap gap-x-2 text-[11px] text-muted-foreground">
+                  {r.exchange && <span>{r.exchange}</span>}
+                  {r.sector && <span>· {r.sector}</span>}
+                </div>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
   );
 }

--- a/src/components/investors/upcoming-events-card.tsx
+++ b/src/components/investors/upcoming-events-card.tsx
@@ -24,12 +24,16 @@ function Row({
   term,
   definition,
   date,
+  dateEnd,
 }: {
   label: string;
   term: string;
   definition: string;
   date?: string;
+  dateEnd?: string;
 }) {
+  const display =
+    date && dateEnd && dateEnd !== date ? `${date} → ${dateEnd}` : date;
   const d = daysUntil(date);
   return (
     <div className="flex flex-wrap items-baseline gap-2 text-sm">
@@ -38,15 +42,17 @@ function Row({
         <span className="font-medium text-foreground">{label}</span>
       </GlossaryTerm>
       <span className="text-muted-foreground">:</span>
-      {date ? (
+      {display ? (
         <>
-          <span className="tabular-nums text-foreground">{date}</span>
+          <span className="tabular-nums text-foreground">{display}</span>
           {d != null && (
-            <span className="text-xs text-muted-foreground">({d === 0 ? "today" : `in ${d} day${d === 1 ? "" : "s"}`})</span>
+            <span className="text-xs text-muted-foreground">
+              ({d === 0 ? "today" : `in ${d} day${d === 1 ? "" : "s"}`})
+            </span>
           )}
         </>
       ) : (
-        <span className="text-muted-foreground">—</span>
+        <span className="text-muted-foreground">Not announced</span>
       )}
     </div>
   );
@@ -55,23 +61,33 @@ function Row({
 export function UpcomingEventsCard({ calendar, loading }: Props) {
   if (loading) return <SkeletonCard />;
 
+  const hasAny =
+    calendar?.exDividendDate != null || calendar?.earningsDate != null;
+
   return (
     <div className="rounded-xl border border-border bg-card/80 p-6">
-      <h3 className="mb-4 text-sm font-semibold text-foreground">Upcoming</h3>
-      <div className="space-y-3">
-        <Row
-          label="Ex-dividend"
-          term="Ex-dividend date"
-          definition="First date the stock trades without the declared dividend; buyers on or after this date do not receive that payment."
-          date={calendar?.exDividendDate}
-        />
-        <Row
-          label="Earnings"
-          term="Earnings date"
-          definition="When the company is scheduled to report quarterly results, if provided by the data source."
-          date={calendar?.earningsDate}
-        />
-      </div>
+      <h3 className="mb-4 text-sm font-semibold text-foreground">Upcoming events</h3>
+      {!hasAny ? (
+        <p className="text-sm text-muted-foreground">
+          No scheduled ex-dividend or earnings dates reported.
+        </p>
+      ) : (
+        <div className="space-y-3">
+          <Row
+            label="Ex-dividend"
+            term="Ex-dividend date"
+            definition="First date the stock trades without the declared dividend; buyers on or after this date do not receive that payment."
+            date={calendar?.exDividendDate}
+          />
+          <Row
+            label="Earnings"
+            term="Earnings date"
+            definition="When the company is scheduled to report quarterly results. Yahoo sometimes gives a window (start → end) rather than a single day."
+            date={calendar?.earningsDate}
+            dateEnd={calendar?.earningsDateEnd}
+          />
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/projection-gap-simulator.tsx
+++ b/src/components/projection-gap-simulator.tsx
@@ -7,6 +7,7 @@ import { ArrowLeftIcon, ArrowRightIcon, CheckIcon } from "lucide-react";
 
 import { surfaceOuterClass } from "@/components/surface-section";
 import { Button } from "@/components/ui/button";
+import { GlossaryTerm } from "@/components/ui/glossary-term";
 import { cn } from "@/lib/utils";
 import { VENDOR_IDS, vendorLabel, vendorAbbr, type VendorId } from "@/lib/vendors";
 import { runSimulator } from "@/lib/simulator/simulator-engine";
@@ -122,6 +123,134 @@ const FAMILIES_NEEDING_CONTEXT: Set<CanonicalEventId> = new Set([
   "secondary-offering",
   "private-placement",
 ]);
+
+type ChoiceOption<T extends string> = {
+  value: T;
+  label: string;
+  /** Tooltip — why it matters and how it shifts the verdict. */
+  hint?: string;
+};
+
+function ChoiceGroup<T extends string>({
+  legend,
+  hint,
+  options,
+  value,
+  onChange,
+  variant = "pill",
+}: {
+  legend: string;
+  hint?: string;
+  options: ReadonlyArray<ChoiceOption<T>>;
+  value: T;
+  onChange: (v: T) => void;
+  variant?: "pill" | "tile";
+}) {
+  if (variant === "tile") {
+    return (
+      <fieldset className="space-y-3">
+        <legend className="text-sm font-medium text-foreground">
+          {hint ? (
+            <GlossaryTerm term={legend} definition={hint}>
+              {legend}
+            </GlossaryTerm>
+          ) : (
+            legend
+          )}
+        </legend>
+        <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
+          {options.map((o) => (
+            <button
+              key={o.value}
+              type="button"
+              onClick={() => onChange(o.value)}
+              aria-pressed={value === o.value}
+              title={o.hint}
+              className={cn(
+                "min-w-0 rounded-2xl border px-3 py-2.5 text-left text-sm transition-all",
+                value === o.value
+                  ? "border-primary/50 bg-primary/15 text-foreground"
+                  : "border-border bg-background/50 text-muted-foreground hover:border-primary/30 hover:text-foreground",
+              )}
+            >
+              <span className="block text-sm font-semibold">{o.label}</span>
+              {o.hint && (
+                <span className="mt-1 block text-[11px] leading-snug text-muted-foreground">
+                  {o.hint}
+                </span>
+              )}
+            </button>
+          ))}
+        </div>
+      </fieldset>
+    );
+  }
+
+  return (
+    <fieldset className="space-y-3">
+      <legend className="text-sm font-medium text-foreground">
+        {hint ? (
+          <GlossaryTerm term={legend} definition={hint}>
+            {legend}
+          </GlossaryTerm>
+        ) : (
+          legend
+        )}
+      </legend>
+      <div className="flex flex-wrap gap-2">
+        {options.map((o) => (
+          <button
+            key={o.value}
+            type="button"
+            onClick={() => onChange(o.value)}
+            title={o.hint}
+            aria-pressed={value === o.value}
+            className={cn(
+              "rounded-full border px-4 py-2 text-sm transition-all",
+              value === o.value
+                ? "border-primary/50 bg-primary/15 text-foreground"
+                : "border-border bg-background/50 text-muted-foreground hover:text-foreground",
+            )}
+          >
+            {o.label}
+          </button>
+        ))}
+      </div>
+    </fieldset>
+  );
+}
+
+function MetricField({
+  label,
+  hint,
+  placeholder,
+  value,
+  onChange,
+}: {
+  label: string;
+  hint: string;
+  placeholder: string;
+  value: string;
+  onChange: (v: string) => void;
+}) {
+  return (
+    <label className="flex min-w-0 flex-col gap-1.5">
+      <span className="flex min-h-[2.75rem] items-start text-xs font-medium leading-snug text-muted-foreground">
+        <GlossaryTerm term={label} definition={hint}>
+          {label}
+        </GlossaryTerm>
+      </span>
+      <input
+        type="text"
+        inputMode="decimal"
+        placeholder={placeholder}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="h-11 w-full rounded-xl border border-border bg-background px-3 text-sm outline-none ring-0 transition-shadow focus-visible:border-primary/50 focus-visible:shadow-[0_0_0_3px_oklch(0.72_0.19_250/0.25)]"
+      />
+    </label>
+  );
+}
 
 export function ProjectionGapSimulator() {
   const [step, setStep] = useState(0);
@@ -425,31 +554,18 @@ export function ProjectionGapSimulator() {
                     ) : (
                       <div className="space-y-6">
                         {input.eventFamily === "rights-issue" && (
-                          <fieldset className="space-y-3">
-                            <legend className="text-sm font-medium text-foreground">Rights</legend>
-                            <div className="flex flex-wrap gap-2">
-                              {(
-                                [
-                                  ["itm", "In the money"],
-                                  ["otm", "Out of the money"],
-                                  ["unknown", "Not sure yet"],
-                                ] as const
-                              ).map(([v, label]) => (
-                                <button
-                                  key={v}
-                                  type="button"
-                                  onClick={() => setInput((p) => ({ ...p, rightsItm: v }))}
-                                  className={cn(
-                                    "rounded-full border px-4 py-2 text-sm transition-all",
-                                    input.rightsItm === v
-                                      ? "border-primary/50 bg-primary/15 text-foreground"
-                                      : "border-border bg-background/50 text-muted-foreground hover:text-foreground",
-                                  )}
-                                >
-                                  {label}
-                                </button>
-                              ))}
-                            </div>
+                          <div className="space-y-4">
+                            <ChoiceGroup
+                              legend="Rights moneyness"
+                              hint="In the money (ITM) means exercising is profitable — high participation is likely, so share count rises. Out of the money (OTM) rights are usually left to lapse — less impact. Vendors vary on how they project this before subscription data is known."
+                              value={input.rightsItm}
+                              onChange={(v) => setInput((p) => ({ ...p, rightsItm: v }))}
+                              options={[
+                                { value: "itm", label: "In the money", hint: "Exercise likely → share count ↑. Vendors with smaller thresholds react first." },
+                                { value: "otm", label: "Out of the money", hint: "Rights usually lapse → minimal share change. Only vendors using theoretical PAF may still adjust." },
+                                { value: "unknown", label: "Not sure yet", hint: "Simulator won't guess — verdict will note the uncertainty." },
+                              ]}
+                            />
                             <label className="flex cursor-pointer items-start gap-3 rounded-2xl border border-border/60 bg-background/30 px-4 py-3 text-sm">
                               <input
                                 type="checkbox"
@@ -459,159 +575,106 @@ export function ProjectionGapSimulator() {
                                 }
                                 className="mt-0.5 size-4 rounded border-border"
                               />
-                              <span className="leading-snug">Final subscription price and ratio are known.</span>
+                              <span className="leading-snug">
+                                <GlossaryTerm
+                                  term="Final terms known"
+                                  definition="Until final subscription price and ratio are announced, FTSE and STOXX often wait and MSCI may use theoretical price. Knowing the final terms lets all vendors project the same adjustment."
+                                >
+                                  Final subscription price and ratio are known.
+                                </GlossaryTerm>
+                              </span>
                             </label>
-                          </fieldset>
+                          </div>
                         )}
 
                         {(input.eventFamily === "merger" || input.eventFamily === "tender-offer") && (
                           <div className="space-y-5">
                             {input.eventFamily === "merger" && (
-                              <fieldset className="space-y-3">
-                                <legend className="text-sm font-medium text-foreground">Deal</legend>
-                                <div className="flex flex-wrap gap-2">
-                                  {(
-                                    [
-                                      ["stock", "Mostly stock"],
-                                      ["cash", "Mostly cash"],
-                                      ["mixed", "Mixed or unclear"],
-                                    ] as const
-                                  ).map(([v, label]) => (
-                                    <button
-                                      key={v}
-                                      type="button"
-                                      onClick={() => setInput((p) => ({ ...p, mnaDealType: v }))}
-                                      className={cn(
-                                        "rounded-full border px-4 py-2 text-sm transition-all",
-                                        input.mnaDealType === v
-                                          ? "border-primary/50 bg-primary/15 text-foreground"
-                                          : "border-border bg-background/50 text-muted-foreground hover:text-foreground",
-                                      )}
-                                    >
-                                      {label}
-                                    </button>
-                                  ))}
-                                </div>
-                              </fieldset>
+                              <ChoiceGroup
+                                legend="Deal consideration"
+                                hint="Cash deals trigger deletion and divisor changes; stock deals also change the acquirer's share count, which each vendor quantifies differently. Mixed deals behave somewhere in between."
+                                value={input.mnaDealType}
+                                onChange={(v) => setInput((p) => ({ ...p, mnaDealType: v }))}
+                                options={[
+                                  { value: "stock", label: "Mostly stock", hint: "Acquirer issues new shares → free float and share count change. Larger divergence across vendors." },
+                                  { value: "cash", label: "Mostly cash", hint: "Target deleted, acquirer unchanged in count. Divergence is mostly about deletion timing." },
+                                  { value: "mixed", label: "Mixed or unclear", hint: "Combination of above — expect both deletion and share-count effects." },
+                                ]}
+                              />
                             )}
-                            <fieldset className="space-y-3">
-                              <legend className="text-sm font-medium text-foreground">Index membership</legend>
-                              <div className="flex flex-wrap gap-2">
-                                {(
-                                  [
-                                    ["target_only", "Target only"],
-                                    ["acquirer_only", "Acquirer only"],
-                                    ["both", "Both in the same index"],
-                                  ] as const
-                                ).map(([v, label]) => (
-                                  <button
-                                    key={v}
-                                    type="button"
-                                    onClick={() => setInput((p) => ({ ...p, mnaIndexParties: v }))}
-                                    className={cn(
-                                      "rounded-full border px-4 py-2 text-sm transition-all",
-                                      input.mnaIndexParties === v
-                                        ? "border-primary/50 bg-primary/15 text-foreground"
-                                        : "border-border bg-background/50 text-muted-foreground hover:text-foreground",
-                                    )}
-                                  >
-                                    {label}
-                                  </button>
-                                ))}
-                              </div>
-                            </fieldset>
+                            <ChoiceGroup
+                              legend="Index membership"
+                              hint="Who is in your managed index decides everything. Only the target, only the acquirer, or both — each path triggers different vendor rules (deletion triggers for the target, share-count adjustments for the acquirer)."
+                              value={input.mnaIndexParties}
+                              onChange={(v) => setInput((p) => ({ ...p, mnaIndexParties: v }))}
+                              options={[
+                                { value: "target_only", label: "Target only", hint: "Expect deletion event — vendor-specific acceptance/float thresholds drive the date." },
+                                { value: "acquirer_only", label: "Acquirer only", hint: "Expect share-count / free-float change on the acquirer — thresholds differ per vendor." },
+                                { value: "both", label: "Both in the same index", hint: "Most complex — deletion of target and adjustment of acquirer can happen on different dates per vendor." },
+                              ]}
+                            />
                           </div>
                         )}
 
                         {input.eventFamily === "spin-off" && (
                           <div className="space-y-5">
-                            <fieldset className="space-y-3">
-                              <legend className="text-sm font-medium text-foreground">Spin-off child</legend>
-                              <div className="flex flex-wrap gap-2">
-                                {(
-                                  [
-                                    ["yes", "Eligible for the index"],
-                                    ["no", "Not eligible"],
-                                    ["unknown", "Unknown"],
-                                  ] as const
-                                ).map(([v, label]) => (
-                                  <button
-                                    key={v}
-                                    type="button"
-                                    onClick={() => setInput((p) => ({ ...p, spinoffChildEligible: v }))}
-                                    className={cn(
-                                      "rounded-full border px-4 py-2 text-sm transition-all",
-                                      input.spinoffChildEligible === v
-                                        ? "border-primary/50 bg-primary/15 text-foreground"
-                                        : "border-border bg-background/50 text-muted-foreground hover:text-foreground",
-                                    )}
-                                  >
-                                    {label}
-                                  </button>
-                                ))}
-                              </div>
-                            </fieldset>
+                            <ChoiceGroup
+                              legend="Spin-off child eligibility"
+                              hint="Is the distributed child allowed in the index at all? If not eligible, no vendor adds it — divergence ends. If eligible, each vendor uses a different placeholder convention before real trading."
+                              value={input.spinoffChildEligible}
+                              onChange={(v) => setInput((p) => ({ ...p, spinoffChildEligible: v }))}
+                              options={[
+                                { value: "yes", label: "Eligible", hint: "Each vendor uses its own placeholder price — divergence in projections is common." },
+                                { value: "no", label: "Not eligible", hint: "No vendor adds it. Parent adjusts only." },
+                                { value: "unknown", label: "Unknown", hint: "Simulator flags eligibility as the key question to answer first." },
+                              ]}
+                            />
                             {input.spinoffChildEligible !== "no" && (
-                              <fieldset className="space-y-3">
-                                <legend className="text-sm font-medium text-foreground">Trading</legend>
-                                <div className="flex flex-wrap gap-2">
-                                  {(
-                                    [
-                                      ["placeholder", "Placeholder or when-issued only"],
-                                      ["live_trade", "Regular market trading"],
-                                      ["unknown", "Unknown"],
-                                    ] as const
-                                  ).map(([v, label]) => (
-                                    <button
-                                      key={v}
-                                      type="button"
-                                      onClick={() => setInput((p) => ({ ...p, spinoffPhase: v }))}
-                                      className={cn(
-                                        "rounded-full border px-4 py-2 text-sm transition-all",
-                                        input.spinoffPhase === v
-                                          ? "border-primary/50 bg-primary/15 text-foreground"
-                                          : "border-border bg-background/50 text-muted-foreground hover:text-foreground",
-                                      )}
-                                    >
-                                      {label}
-                                    </button>
-                                  ))}
-                                </div>
-                              </fieldset>
+                              <ChoiceGroup
+                                legend="Trading phase"
+                                hint="Before regular trading starts, vendors diverge the most: some use theoretical price, some when-issued price, some a zero placeholder, some wait. Once live trades print, most converge."
+                                value={input.spinoffPhase}
+                                onChange={(v) => setInput((p) => ({ ...p, spinoffPhase: v }))}
+                                options={[
+                                  { value: "placeholder", label: "Placeholder / when-issued", hint: "Expect price divergence — S&P, MSCI, FTSE, STOXX, Solactive each use different placeholders." },
+                                  { value: "live_trade", label: "Regular market trading", hint: "Real last-trade price — divergence narrows significantly." },
+                                  { value: "unknown", label: "Unknown", hint: "Verdict highlights timing phase as the likely cause." },
+                                ]}
+                              />
                             )}
                           </div>
                         )}
 
                         {isDividendLike && (
-                          <fieldset className="space-y-3">
-                            <legend className="text-sm font-medium text-foreground">
-                              Index variant you are comparing
-                            </legend>
-                            <div className="flex flex-wrap gap-2">
-                              {(
-                                [
-                                  ["pr", "PR"],
-                                  ["tr", "TR"],
-                                  ["ntr", "NTR"],
-                                  ["unknown", "Not applicable"],
-                                ] as const
-                              ).map(([v, label]) => (
-                                <button
-                                  key={v}
-                                  type="button"
-                                  onClick={() => setInput((p) => ({ ...p, indexReturnVariant: v }))}
-                                  className={cn(
-                                    "rounded-full border px-4 py-2 text-sm transition-all",
-                                    input.indexReturnVariant === v
-                                      ? "border-primary/50 bg-primary/15 text-foreground"
-                                      : "border-border bg-background/50 text-muted-foreground hover:text-foreground",
-                                  )}
-                                >
-                                  {label}
-                                </button>
-                              ))}
-                            </div>
-                          </fieldset>
+                          <ChoiceGroup
+                            variant="tile"
+                            legend="Index Variant (PR / TR / NTR)"
+                            hint="Return variants decide how vendors treat dividends. PR ignores dividends (price-only) so special cash dividends above threshold still adjust price. TR reinvests the gross dividend — no price adjustment unless it's classified as special. NTR reinvests the net-of-withholding-tax dividend — same rule as TR but each vendor uses its own tax table. Pick the variant you are comparing across vendors."
+                            value={input.indexReturnVariant}
+                            onChange={(v) => setInput((p) => ({ ...p, indexReturnVariant: v }))}
+                            options={[
+                              {
+                                value: "pr",
+                                label: "PR",
+                                hint: "Price Return — dividends not reinvested. Only specials above vendor threshold cause a price adjustment. Biggest driver of divergence: what each vendor labels 'special'.",
+                              },
+                              {
+                                value: "tr",
+                                label: "TR",
+                                hint: "Gross Total Return — all dividends reinvested at gross. No price adjustment for ordinary cash; specials may still adjust. Divergence comes from the ordinary-vs-special classification.",
+                              },
+                              {
+                                value: "ntr",
+                                label: "NTR",
+                                hint: "Net Total Return — dividends reinvested after withholding tax. Each vendor uses its own tax-rate table per country, so the reinvested amount differs even when the cash dividend is identical.",
+                              },
+                              {
+                                value: "unknown",
+                                label: "Not applicable",
+                                hint: "Simulator won't use variant-specific logic.",
+                              },
+                            ]}
+                          />
                         )}
                       </div>
                     )}
@@ -619,81 +682,57 @@ export function ProjectionGapSimulator() {
                     <div className="rounded-3xl border border-border/60 bg-background/25 p-5 sm:p-6">
                       <p className="text-sm font-medium text-foreground">Optional numbers</p>
                       <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
-                        Rough percentages are fine. Leave blank if unknown — the simulator will say it cannot make the call rather than guess.
+                        Rough percentages are fine. Leave blank if unknown — the simulator will say it cannot make the call rather than guess. Hover a label for how each metric is used.
                       </p>
-                      <div className="mt-4 grid grid-cols-1 gap-4 md:grid-cols-2">
-                        <label className="block space-y-1.5">
-                          <span className="text-xs font-medium text-muted-foreground">
-                            Dividend yield (% of price)
-                          </span>
-                          <input
-                            type="text"
-                            inputMode="decimal"
-                            placeholder="e.g. 5"
-                            value={input.metrics.dividendYieldPct}
-                            onChange={(e) =>
-                              setInput((p) => ({
-                                ...p,
-                                metrics: { ...p.metrics, dividendYieldPct: e.target.value },
-                              }))
-                            }
-                            className="w-full rounded-xl border border-border bg-background px-3 py-2.5 text-sm outline-none ring-0 transition-shadow focus-visible:border-primary/50 focus-visible:shadow-[0_0_0_3px_oklch(0.72_0.19_250/0.25)]"
-                          />
-                        </label>
-                        <label className="block space-y-1.5">
-                          <span className="text-xs font-medium text-muted-foreground">
-                            Free-float change (points) / share-count change (%)
-                          </span>
-                          <input
-                            type="text"
-                            inputMode="decimal"
-                            placeholder="e.g. 6 or -3"
-                            value={input.metrics.freeFloatChangePp}
-                            onChange={(e) =>
-                              setInput((p) => ({
-                                ...p,
-                                metrics: { ...p.metrics, freeFloatChangePp: e.target.value },
-                              }))
-                            }
-                            className="w-full rounded-xl border border-border bg-background px-3 py-2.5 text-sm outline-none focus-visible:border-primary/50 focus-visible:shadow-[0_0_0_3px_oklch(0.72_0.19_250/0.25)]"
-                          />
-                        </label>
-                        <label className="block space-y-1.5">
-                          <span className="text-xs font-medium text-muted-foreground">
-                            Tender acceptance (%)
-                          </span>
-                          <input
-                            type="text"
-                            inputMode="decimal"
-                            placeholder="e.g. 72"
-                            value={input.metrics.tenderAcceptancePct}
-                            onChange={(e) =>
-                              setInput((p) => ({
-                                ...p,
-                                metrics: { ...p.metrics, tenderAcceptancePct: e.target.value },
-                              }))
-                            }
-                            className="w-full rounded-xl border border-border bg-background px-3 py-2.5 text-sm outline-none focus-visible:border-primary/50 focus-visible:shadow-[0_0_0_3px_oklch(0.72_0.19_250/0.25)]"
-                          />
-                        </label>
-                        <label className="block space-y-1.5">
-                          <span className="text-xs font-medium text-muted-foreground">
-                            Rights discount vs theoretical (%)
-                          </span>
-                          <input
-                            type="text"
-                            inputMode="decimal"
-                            placeholder="e.g. 15"
-                            value={input.metrics.rightsDiscountPct}
-                            onChange={(e) =>
-                              setInput((p) => ({
-                                ...p,
-                                metrics: { ...p.metrics, rightsDiscountPct: e.target.value },
-                              }))
-                            }
-                            className="w-full rounded-xl border border-border bg-background px-3 py-2.5 text-sm outline-none focus-visible:border-primary/50 focus-visible:shadow-[0_0_0_3px_oklch(0.72_0.19_250/0.25)]"
-                          />
-                        </label>
+                      <div className="mt-5 grid min-w-0 grid-cols-1 items-start gap-x-5 gap-y-5 md:grid-cols-2">
+                        <MetricField
+                          label="Dividend yield (% of price)"
+                          hint="The cash dividend divided by the latest price. Used to flag 'special' dividends — when yield exceeds each vendor's threshold (e.g. S&P > 5% of price for some indices), the dividend triggers a PR adjustment instead of being treated as ordinary."
+                          placeholder="e.g. 5"
+                          value={input.metrics.dividendYieldPct}
+                          onChange={(v) =>
+                            setInput((p) => ({
+                              ...p,
+                              metrics: { ...p.metrics, dividendYieldPct: v },
+                            }))
+                          }
+                        />
+                        <MetricField
+                          label="Free-float change (pp) / share-count change (%)"
+                          hint="Change in free-float points or share count after the event. Vendors use different materiality thresholds (e.g. 5 pp, 5 %, 10 %), so the same change can trigger adjustments at some vendors and be deferred to the next review at others."
+                          placeholder="e.g. 6 or -3"
+                          value={input.metrics.freeFloatChangePp}
+                          onChange={(v) =>
+                            setInput((p) => ({
+                              ...p,
+                              metrics: { ...p.metrics, freeFloatChangePp: v },
+                            }))
+                          }
+                        />
+                        <MetricField
+                          label="Tender acceptance (%)"
+                          hint="Share of the target accepted in a tender or M&A. Vendors use different deletion triggers — e.g. S&P may delete at 90 % or earlier if free float drops below 15 %; STOXX needs both ≥ 85 % accepted and free float < 10 %."
+                          placeholder="e.g. 72"
+                          value={input.metrics.tenderAcceptancePct}
+                          onChange={(v) =>
+                            setInput((p) => ({
+                              ...p,
+                              metrics: { ...p.metrics, tenderAcceptancePct: v },
+                            }))
+                          }
+                        />
+                        <MetricField
+                          label="Rights discount vs theoretical (%)"
+                          hint="How far the rights subscription price sits below the theoretical ex-rights price. A deeper discount means the rights are more in-the-money, higher participation is expected, and the adjustment factor each vendor applies diverges more."
+                          placeholder="e.g. 15"
+                          value={input.metrics.rightsDiscountPct}
+                          onChange={(v) =>
+                            setInput((p) => ({
+                              ...p,
+                              metrics: { ...p.metrics, rightsDiscountPct: v },
+                            }))
+                          }
+                        />
                       </div>
                     </div>
                   </div>

--- a/src/lib/investors/format.ts
+++ b/src/lib/investors/format.ts
@@ -1,14 +1,104 @@
-export function formatUsd(n: number): string {
-  return new Intl.NumberFormat("en-US", {
-    style: "currency",
-    currency: "USD",
-    maximumFractionDigits: 4,
-  }).format(n);
+const CURRENCY_SYMBOLS: Record<string, string> = {
+  USD: "US$",
+  HKD: "HK$",
+  CNY: "CN¥",
+  JPY: "¥",
+  GBP: "£",
+  GBp: "£",
+  EUR: "€",
+  AUD: "A$",
+  CAD: "C$",
+  INR: "₹",
+  KRW: "₩",
+  SGD: "S$",
+  TWD: "NT$",
+  CHF: "CHF",
+  SEK: "SEK",
+  NOK: "NOK",
+  DKK: "DKK",
+};
+
+function resolveCurrency(code?: string): string {
+  if (!code) return "USD";
+  return code.toUpperCase() === "GBP" ? "GBP" : code.toUpperCase();
+}
+
+function resolveLocale(code?: string): string {
+  switch (resolveCurrency(code)) {
+    case "EUR":
+      return "en-IE";
+    case "GBP":
+      return "en-GB";
+    case "JPY":
+      return "ja-JP";
+    case "HKD":
+      return "zh-HK";
+    case "CNY":
+      return "zh-CN";
+    case "INR":
+      return "en-IN";
+    case "KRW":
+      return "ko-KR";
+    case "AUD":
+      return "en-AU";
+    case "CAD":
+      return "en-CA";
+    default:
+      return "en-US";
+  }
+}
+
+/** Currency-aware formatter. GBp (London pence) is converted to GBP. */
+export function formatCurrency(n: number, currency?: string): string {
+  const code = resolveCurrency(currency);
+  let value = n;
+  if (currency === "GBp" || currency === "GBX") value = n / 100;
+
+  try {
+    return new Intl.NumberFormat(resolveLocale(code), {
+      style: "currency",
+      currency: code,
+      maximumFractionDigits: Math.abs(value) >= 100 ? 2 : 4,
+    }).format(value);
+  } catch {
+    const sym = CURRENCY_SYMBOLS[code] ?? "";
+    const formatted = value.toLocaleString("en-US", {
+      maximumFractionDigits: 4,
+    });
+    return `${sym}${formatted}`;
+  }
+}
+
+/** Alias kept for components that still import `formatUsd`. */
+export function formatUsd(n: number, currency?: string): string {
+  return formatCurrency(n, currency);
 }
 
 export function formatPct(n: number): string {
   const sign = n > 0 ? "+" : "";
   return `${sign}${n.toFixed(2)}%`;
+}
+
+/** Formats a large integer like market cap: 1.23T, 45.6B, 789M. */
+export function formatCompact(n?: number, currency?: string): string | undefined {
+  if (n == null || !Number.isFinite(n)) return undefined;
+  const code = resolveCurrency(currency);
+  try {
+    return new Intl.NumberFormat(resolveLocale(code), {
+      style: "currency",
+      currency: code,
+      notation: "compact",
+      maximumFractionDigits: 2,
+    }).format(n);
+  } catch {
+    const sym = CURRENCY_SYMBOLS[code] ?? "";
+    return `${sym}${n.toLocaleString("en-US", { notation: "compact", maximumFractionDigits: 2 })}`;
+  }
+}
+
+export function formatInteger(n?: number): string | undefined {
+  if (n == null || !Number.isFinite(n)) return undefined;
+  return new Intl.NumberFormat("en-US", { notation: "compact", maximumFractionDigits: 2 }).format(n);
 }
 
 /** Days from today to ISO date string (UTC midnight); undefined if invalid/past. */

--- a/src/lib/investors/types.ts
+++ b/src/lib/investors/types.ts
@@ -8,13 +8,50 @@ export type InvestorQuote = {
   name?: string;
   price?: number;
   changePct?: number;
+  changeAbs?: number;
   sector?: string;
+  industry?: string;
   exchange?: string;
+  /** ISO currency code (e.g. "USD", "HKD", "EUR") used for price formatting. */
+  currency?: string;
+  marketState?: string;
+  /** Previous regular close. */
+  previousClose?: number;
+  /** Today/last session day range. */
+  dayLow?: number;
+  dayHigh?: number;
+  /** 52-week range. */
+  yearLow?: number;
+  yearHigh?: number;
+  /** Volumes in shares. */
+  volume?: number;
+  avgVolume?: number;
+  /** Market cap in listing currency. */
+  marketCap?: number;
+  /** Trailing PE ratio, beta, EPS as reported by the data source. */
+  peTrailing?: number;
+  beta?: number;
+  epsTrailing?: number;
+  /** Country + quote type help global users (EQUITY, ETF, INDEX…). */
+  country?: string;
+  quoteType?: string;
 };
 
 export type InvestorCalendar = {
   exDividendDate?: string;
   earningsDate?: string;
+  /** Estimated earnings window end, if provided. */
+  earningsDateEnd?: string;
+};
+
+/** Shared row shape used by the search typeahead. */
+export type InvestorSearchResult = {
+  symbol: string;
+  name?: string;
+  exchange?: string;
+  quoteType?: string;
+  sector?: string;
+  country?: string;
 };
 
 export type InvestorTickerResponse = {
@@ -25,6 +62,11 @@ export type InvestorTickerResponse = {
   splits: InvestorSplitRow[];
   calendar?: InvestorCalendar;
   /** `dividendYield` is a percentage for display (e.g. 2.5 means 2.5%), from Yahoo raw × 100. */
-  metrics?: { dividendRate?: number; dividendYield?: number };
+  metrics?: {
+    dividendRate?: number;
+    dividendYield?: number;
+    payoutRatio?: number;
+    fiveYearAvgDividendYield?: number;
+  };
   warnings: string[];
 };

--- a/src/lib/investors/yahoo-finance.ts
+++ b/src/lib/investors/yahoo-finance.ts
@@ -2,6 +2,7 @@ import type {
   InvestorCalendar,
   InvestorDividendRow,
   InvestorQuote,
+  InvestorSearchResult,
   InvestorSplitRow,
   InvestorTickerResponse,
 } from "./types";
@@ -10,15 +11,16 @@ const YAHUA =
   "Mozilla/5.0 (compatible; KnowledgeHub/1.0; +https://corporate-action.vercel.app)";
 
 const UPSTREAM_REVALIDATE_SEC = 300;
+const SEARCH_REVALIDATE_SEC = 600;
 
 function sleep(ms: number): Promise<void> {
   return new Promise((r) => setTimeout(r, ms));
 }
 
-async function fetchJson<T>(url: string): Promise<T> {
+async function fetchJson<T>(url: string, revalidate: number): Promise<T> {
   const opts = {
     headers: { "User-Agent": YAHUA, Accept: "application/json" },
-    next: { revalidate: UPSTREAM_REVALIDATE_SEC },
+    next: { revalidate },
   } as const;
 
   let res = await fetch(url, opts);
@@ -42,7 +44,12 @@ type ChartResult = {
         longName?: string;
         shortName?: string;
         exchangeName?: string;
+        fullExchangeName?: string;
+        instrumentType?: string;
         quoteType?: string;
+        currency?: string;
+        financialCurrency?: string;
+        marketState?: string;
       };
       events?: {
         dividends?: Record<string, { amount?: number; date?: number }>;
@@ -59,18 +66,59 @@ type ChartResult = {
 type QuoteSummaryResult = {
   quoteSummary?: {
     result?: Array<{
-      summaryProfile?: { sector?: string };
+      summaryProfile?: {
+        sector?: string;
+        industry?: string;
+        country?: string;
+      };
+      quoteType?: {
+        longName?: string;
+        shortName?: string;
+        exchange?: string;
+        quoteType?: string;
+      };
       price?: {
         regularMarketPrice?: { raw?: number };
+        regularMarketChange?: { raw?: number };
         regularMarketChangePercent?: { raw?: number };
+        regularMarketPreviousClose?: { raw?: number };
+        regularMarketDayLow?: { raw?: number };
+        regularMarketDayHigh?: { raw?: number };
+        regularMarketVolume?: { raw?: number };
+        averageDailyVolume10Day?: { raw?: number };
+        averageDailyVolume3Month?: { raw?: number };
+        marketCap?: { raw?: number };
+        currency?: string;
+        exchangeName?: string;
+        longName?: string;
+        shortName?: string;
+        marketState?: string;
       };
       summaryDetail?: {
         dividendRate?: { raw?: number };
         dividendYield?: { raw?: number };
+        payoutRatio?: { raw?: number };
+        fiveYearAvgDividendYield?: { raw?: number };
         exDividendDate?: { raw?: number };
+        trailingPE?: { raw?: number };
+        beta?: { raw?: number };
+        fiftyTwoWeekLow?: { raw?: number };
+        fiftyTwoWeekHigh?: { raw?: number };
+        currency?: string;
+        dayLow?: { raw?: number };
+        dayHigh?: { raw?: number };
+        averageVolume?: { raw?: number };
+        regularMarketVolume?: { raw?: number };
+        marketCap?: { raw?: number };
+        previousClose?: { raw?: number };
+      };
+      defaultKeyStatistics?: {
+        trailingEps?: { raw?: number };
+        beta?: { raw?: number };
       };
       calendarEvents?: {
         exDividendDate?: { raw?: number };
+        dividendDate?: { raw?: number };
         earnings?: {
           earningsDate?: Array<{ raw?: number }>;
         };
@@ -78,6 +126,23 @@ type QuoteSummaryResult = {
     }>;
     error?: { description?: string };
   };
+};
+
+type SearchResultRaw = {
+  quotes?: Array<{
+    symbol?: string;
+    shortname?: string;
+    longname?: string;
+    quoteType?: string;
+    typeDisp?: string;
+    exchDisp?: string;
+    exchange?: string;
+    sector?: string;
+    industry?: string;
+    sectorDisp?: string;
+    industryDisp?: string;
+    isYahooFinance?: boolean;
+  }>;
 };
 
 function isoDay(tsSec?: number): string | undefined {
@@ -90,13 +155,52 @@ function ratioFromSplit(n?: number, d?: number): string {
   return `${n}:${d}`;
 }
 
-/** Normalize user input to Yahoo symbol (e.g. brk.b → BRK-B). */
+/**
+ * Normalize user input to a Yahoo symbol.
+ *
+ * - Uppercases & trims whitespace.
+ * - Keeps suffixes like `.HK`, `.TO`, `.L`, `.T`, `.AX`, `.PA`, etc.
+ * - Converts the US class-share convention (`BRK.B` → `BRK-B`) only when
+ *   nothing after the dot looks like a market suffix (i.e. a single letter).
+ */
 export function normalizeTicker(raw: string): string {
-  return raw
-    .trim()
-    .toUpperCase()
-    .replace(/\s+/g, "")
-    .replace(/\./g, "-");
+  const base = raw.trim().toUpperCase().replace(/\s+/g, "");
+  if (!base) return "";
+  const dotIdx = base.lastIndexOf(".");
+  if (dotIdx === -1) return base;
+  const suffix = base.slice(dotIdx + 1);
+  if (suffix.length === 1) {
+    return `${base.slice(0, dotIdx)}-${suffix}`;
+  }
+  return base;
+}
+
+export async function searchSymbols(
+  query: string,
+  limit = 8,
+): Promise<InvestorSearchResult[]> {
+  const q = query.trim();
+  if (!q) return [];
+  const url = `https://query2.finance.yahoo.com/v1/finance/search?q=${encodeURIComponent(q)}&quotesCount=${limit}&newsCount=0&listsCount=0&enableFuzzyQuery=true&enableNavLinks=false&enableEnhancedTrivialQuery=false`;
+  try {
+    const json = await fetchJson<SearchResultRaw>(url, SEARCH_REVALIDATE_SEC);
+    const out: InvestorSearchResult[] = [];
+    for (const q of json.quotes ?? []) {
+      if (!q.symbol) continue;
+      if (q.isYahooFinance === false) continue;
+      out.push({
+        symbol: q.symbol,
+        name: q.longname ?? q.shortname,
+        exchange: q.exchDisp ?? q.exchange,
+        quoteType: q.typeDisp ?? q.quoteType,
+        sector: q.sectorDisp ?? q.sector,
+      });
+      if (out.length >= limit) break;
+    }
+    return out;
+  } catch {
+    return [];
+  }
 }
 
 export async function buildInvestorPayload(
@@ -104,16 +208,18 @@ export async function buildInvestorPayload(
 ): Promise<InvestorTickerResponse> {
   const warnings: string[] = [];
   const sym = normalizeTicker(ticker);
-  if (!sym || !/^[A-Z0-9.\-]+$/.test(sym)) {
+  if (!sym || !/^[A-Z0-9.\-=^]+$/.test(sym)) {
     throw new Error("INVALID_TICKER");
   }
 
   const chartUrl = `https://query1.finance.yahoo.com/v8/finance/chart/${encodeURIComponent(sym)}?interval=1d&range=10y&events=div%7Csplit`;
-  const summaryUrl = `https://query1.finance.yahoo.com/v10/finance/quoteSummary/${encodeURIComponent(sym)}?modules=summaryProfile,price,summaryDetail,calendarEvents`;
+  const summaryUrl = `https://query1.finance.yahoo.com/v10/finance/quoteSummary/${encodeURIComponent(sym)}?modules=summaryProfile,quoteType,price,summaryDetail,calendarEvents,defaultKeyStatistics`;
 
   const [chartJson, summaryJson] = await Promise.all([
-    fetchJson<ChartResult>(chartUrl),
-    fetchJson<QuoteSummaryResult>(summaryUrl).catch(() => null),
+    fetchJson<ChartResult>(chartUrl, UPSTREAM_REVALIDATE_SEC),
+    fetchJson<QuoteSummaryResult>(summaryUrl, UPSTREAM_REVALIDATE_SEC).catch(
+      () => null,
+    ),
   ]);
 
   const err = chartJson.chart?.error?.description;
@@ -129,6 +235,7 @@ export async function buildInvestorPayload(
   const meta = result.meta;
   const price = meta.regularMarketPrice;
   const prev = meta.chartPreviousClose;
+  let changeAbs: number | undefined;
   let changePct: number | undefined;
   if (
     price != null &&
@@ -137,14 +244,20 @@ export async function buildInvestorPayload(
     Number.isFinite(price) &&
     Number.isFinite(prev)
   ) {
-    changePct = ((price - prev) / prev) * 100;
+    changeAbs = price - prev;
+    changePct = (changeAbs / prev) * 100;
   }
 
   const quote: InvestorQuote = {
     name: meta.longName ?? meta.shortName,
     price,
     changePct,
-    exchange: meta.exchangeName,
+    changeAbs,
+    exchange: meta.fullExchangeName ?? meta.exchangeName,
+    currency: meta.currency,
+    quoteType: meta.quoteType ?? meta.instrumentType,
+    marketState: meta.marketState,
+    previousClose: prev,
   };
 
   const divMap = result.events?.dividends ?? {};
@@ -155,7 +268,7 @@ export async function buildInvestorPayload(
     }))
     .filter((r) => r.date)
     .sort((a, b) => b.date!.localeCompare(a.date!))
-    .slice(0, 5)
+    .slice(0, 8)
     .map((r) => ({ date: r.date!, amount: r.amount }));
 
   const splitMap = result.events?.splits ?? {};
@@ -169,44 +282,112 @@ export async function buildInvestorPayload(
     .slice(0, 8)
     .map((r) => ({ date: r.date!, ratio: r.ratio }));
 
-  if (dividends.length === 0) {
-    warnings.push("No dividend history in chart range (or none paid).");
-  }
-
   let calendar: InvestorCalendar | undefined;
   let metrics: InvestorTickerResponse["metrics"];
-  let sector: string | undefined;
 
   const qr = summaryJson?.quoteSummary?.result?.[0];
   if (qr) {
-    sector = qr.summaryProfile?.sector;
+    const prof = qr.summaryProfile;
+    if (prof?.sector) quote.sector = prof.sector;
+    if (prof?.industry) quote.industry = prof.industry;
+    if (prof?.country) quote.country = prof.country;
+
+    const qt = qr.quoteType;
+    if (qt?.quoteType) quote.quoteType = qt.quoteType;
+    if (!quote.name) quote.name = qt?.longName ?? qt?.shortName;
+
     const p = qr.price;
     if (p?.regularMarketPrice?.raw != null) {
       quote.price = p.regularMarketPrice.raw;
     }
+    if (p?.regularMarketChange?.raw != null) {
+      quote.changeAbs = p.regularMarketChange.raw;
+    }
     if (p?.regularMarketChangePercent?.raw != null) {
       quote.changePct = p.regularMarketChangePercent.raw;
     }
+    if (p?.regularMarketPreviousClose?.raw != null) {
+      quote.previousClose = p.regularMarketPreviousClose.raw;
+    }
+    if (p?.regularMarketDayLow?.raw != null) quote.dayLow = p.regularMarketDayLow.raw;
+    if (p?.regularMarketDayHigh?.raw != null) quote.dayHigh = p.regularMarketDayHigh.raw;
+    if (p?.regularMarketVolume?.raw != null) quote.volume = p.regularMarketVolume.raw;
+    const avgV =
+      p?.averageDailyVolume3Month?.raw ?? p?.averageDailyVolume10Day?.raw;
+    if (avgV != null) quote.avgVolume = avgV;
+    if (p?.marketCap?.raw != null) quote.marketCap = p.marketCap.raw;
+    if (p?.currency) quote.currency = p.currency;
+    if (p?.marketState) quote.marketState = p.marketState;
+    if (p?.exchangeName && !quote.exchange) quote.exchange = p.exchangeName;
+    if (p?.longName && !quote.name) quote.name = p.longName;
+
+    const sd = qr.summaryDetail;
+    if (sd) {
+      if (sd.fiftyTwoWeekLow?.raw != null) quote.yearLow = sd.fiftyTwoWeekLow.raw;
+      if (sd.fiftyTwoWeekHigh?.raw != null) quote.yearHigh = sd.fiftyTwoWeekHigh.raw;
+      if (sd.trailingPE?.raw != null) quote.peTrailing = sd.trailingPE.raw;
+      if (sd.beta?.raw != null) quote.beta = sd.beta.raw;
+      if (quote.dayLow == null && sd.dayLow?.raw != null) quote.dayLow = sd.dayLow.raw;
+      if (quote.dayHigh == null && sd.dayHigh?.raw != null) quote.dayHigh = sd.dayHigh.raw;
+      if (quote.volume == null && sd.regularMarketVolume?.raw != null) {
+        quote.volume = sd.regularMarketVolume.raw;
+      }
+      if (quote.avgVolume == null && sd.averageVolume?.raw != null) {
+        quote.avgVolume = sd.averageVolume.raw;
+      }
+      if (quote.marketCap == null && sd.marketCap?.raw != null) {
+        quote.marketCap = sd.marketCap.raw;
+      }
+      if (quote.previousClose == null && sd.previousClose?.raw != null) {
+        quote.previousClose = sd.previousClose.raw;
+      }
+    }
+
+    const dks = qr.defaultKeyStatistics;
+    if (dks?.trailingEps?.raw != null) quote.epsTrailing = dks.trailingEps.raw;
+    if (quote.beta == null && dks?.beta?.raw != null) quote.beta = dks.beta.raw;
+
     const exRaw =
       qr.calendarEvents?.exDividendDate?.raw ??
       qr.summaryDetail?.exDividendDate?.raw;
-    const earnRaw = qr.calendarEvents?.earnings?.earningsDate?.[0]?.raw;
+    const earnArr = qr.calendarEvents?.earnings?.earningsDate ?? [];
+    const earnStart = earnArr[0]?.raw;
+    const earnEnd = earnArr[1]?.raw;
 
     calendar = {
       exDividendDate: exRaw != null ? isoDay(exRaw) : undefined,
-      earningsDate: earnRaw != null ? isoDay(earnRaw) : undefined,
+      earningsDate: earnStart != null ? isoDay(earnStart) : undefined,
+      earningsDateEnd:
+        earnEnd != null && earnEnd !== earnStart ? isoDay(earnEnd) : undefined,
     };
 
+    metrics = {};
     const dr = qr.summaryDetail?.dividendRate?.raw;
     const dy = qr.summaryDetail?.dividendYield?.raw;
-    metrics = {};
+    const pr = qr.summaryDetail?.payoutRatio?.raw;
+    const fy = qr.summaryDetail?.fiveYearAvgDividendYield?.raw;
     if (dr != null) metrics.dividendRate = dr;
     if (dy != null) metrics.dividendYield = dy * 100;
+    if (pr != null) metrics.payoutRatio = pr * 100;
+    if (fy != null) metrics.fiveYearAvgDividendYield = fy;
+    if (
+      metrics.dividendRate == null &&
+      metrics.dividendYield == null &&
+      metrics.payoutRatio == null &&
+      metrics.fiveYearAvgDividendYield == null
+    ) {
+      metrics = undefined;
+    }
   } else {
-    warnings.push("Quote summary unavailable; calendar and some metrics may be missing.");
+    warnings.push(
+      "Quote summary unavailable — calendar and fundamentals may be missing.",
+    );
   }
 
-  if (sector) quote.sector = sector;
+  const qt = (quote.quoteType ?? "").toUpperCase();
+  if (dividends.length === 0 && (qt === "EQUITY" || qt === "ETF" || qt === "")) {
+    warnings.push("No dividend history in the last 10 years.");
+  }
 
   return {
     ticker: meta.symbol ?? sym,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Makes the **Projection Gap Simulator** more self-explanatory and rebuilds the **Investor snapshot** page for global coverage with richer, meaningful data.

## Home page
- Removes the duplicated "Related tools" strip that repeated _Vendor thresholds / Investor snapshot / Find divergence point_ right next to the hero buttons.

## Projection gap simulator
- Added inline tooltips on the **Index Variant (PR / TR / NTR)** chooser explaining how each variant changes the simulation (PR = price-only, only specials adjust; TR = gross reinvest; NTR = net-of-WHT reinvest — each vendor's tax table differs).
- Added tooltips + contextual sub-labels for every context pill across families:
  - Rights issue: moneyness (ITM / OTM / unknown), final-terms-known toggle.
  - M&A / tender: deal consideration (stock / cash / mixed), index membership (target / acquirer / both).
  - Spin-off: child eligibility + trading phase.
- **Fixed alignment of the Optional numbers grid** — labels now share a common line-height + min-height, inputs share a fixed height, and every input has a hover tooltip explaining how it feeds the verdict.
- Extracted a reusable `ChoiceGroup` (pill / tile variants) + `MetricField` helper inside the simulator component to kill duplication.

## Investor snapshot
- **Global market support:** the page now advertises + handles any Yahoo-covered symbol — `.HK`, `.T`, `.L`, `.DE`, `.TO`, `.AX`, `.PA`, `.SS`, etc. `normalizeTicker` keeps multi-letter market suffixes untouched while still mapping US class shares (`BRK.B` → `BRK-B`).
- **Name + ticker search:** new `GET /api/investors/search?q=` hits Yahoo `v1/finance/search` and the redesigned search bar is a proper combobox with debounced suggestions (symbol, long name, exchange, sector/type). Keyboard nav (↑/↓/Enter/Escape) included.
- **Currency-aware formatting:** new `formatCurrency` / `formatCompact` helpers use `Intl.NumberFormat` with the quote's reported currency (USD, HKD, EUR, JPY, GBP incl. London pence conversion, INR, KRW, AUD, CAD, …).
- **Richer, meaningful quote strip:** previous close, day range, 52-week range, market cap, volume, average volume, trailing P/E, trailing EPS, beta, plus tags for currency / market state / exchange / quote type / country / sector / industry — instead of a mostly-empty line.
- **Dividend summary** now reports annual rate, yield, 5-yr avg yield, and payout ratio with glossary tooltips, plus a graceful "no dividend information reported" fallback for non-dividend paying stocks.
- **Upcoming events** supports earnings windows (`start → end`) and shows a clear "Not announced" state instead of an empty dash.
- Updated page copy + example tickers to include global names (Apple, Microsoft, HSBC `0005.HK`, Toyota `7203.T`, Vodafone `VOD.L`, SAP.DE, BHP.AX).

## Checks
- `npx tsc --noEmit` — clean
- `npm run lint` — clean
- `npm run build` — clean (new `/api/investors/search` route registered)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a5378635-762b-4d8d-8fca-0b02aca9ddec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a5378635-762b-4d8d-8fca-0b02aca9ddec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

